### PR TITLE
pglogical_drop_node should release the LWLock it acquires

### DIFF
--- a/pglogical_functions.c
+++ b/pglogical_functions.c
@@ -226,7 +226,7 @@ pglogical_drop_node(PG_FUNCTION_ARGS)
 					strncmp(NameStr(slot->data.name), "pgl_", 4) != 0)
 				{
 					SpinLockRelease(&slot->mutex);
-					LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+					LWLockRelease(ReplicationSlotControlLock);
 					continue;
 				}
 
@@ -237,7 +237,7 @@ pglogical_drop_node(PG_FUNCTION_ARGS)
 #endif
 				{
 					SpinLockRelease(&slot->mutex);
-					LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+					LWLockRelease(ReplicationSlotControlLock);
 					ereport(ERROR,
 							(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 							 errmsg("cannot drop node \"%s\" because replication slot \"%s\" on the node is still active",
@@ -245,7 +245,7 @@ pglogical_drop_node(PG_FUNCTION_ARGS)
 							 errhint("drop the subscriptions first")));
 				}
 				SpinLockRelease(&slot->mutex);
-				LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+				LWLockRelease(ReplicationSlotControlLock);
 
 				ReplicationSlotDrop(NameStr(slot->data.name));
 			}


### PR DESCRIPTION
Failing to release these locks causes subsequent acquires for exclusive access to fail.

This can be reproduced with the following steps:

- Create a provider node
- Drop the node
- Recreate the node
- Create a subscription to that node

That subscription will never be able to complete the sync because it will be blocked while trying to acquire the ReplicationSlotControlLock in exclusive mode while creating the replication slot on the provider

Original PR https://github.com/2ndQuadrant/postgres/pull/3