### PR TITLE
Fix Makefile and compilation instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ PG_CPPFLAGS += $(addprefix -I,$(realpath $(srcdir)/compat95))
 OBJS += $(srcdir)/compat95/pglogical_compat.o
 endif
 
+PG_CPPFLAGS += $(addprefix -I,$(realpath $(srcdir)/pglogical_output/))
+
 PGXS = $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ you don't have `pg_config`.
 Then run `make USE_PGXS=1` to compile, and `make USE_PGXS=1 install` to
 install. You might need to use `sudo` for the install step.
 
+You also have to initialize the subprojects.
+
 e.g. for a typical Fedora or RHEL 7 install, assuming you're using the
 [yum.postgresql.org](http://yum.postgresql.org) packages for PostgreSQL:
 
     sudo dnf install postgresql95-devel
+    git submodule update --init
     PATH=/usr/pgsql-9.5/bin:$PATH make USE_PGXS=1 clean all
     sudo PATH=/usr/pgsql-9.5/bin:$PATH make USE_PGXS=1 install
+
 
 ## Usage
 


### PR DESCRIPTION
The compilation instructions from source do not work at the moment.

This patch (to the Makefile and the docs) allowed me to successfully compile pglogical from the git repository.