### PR TITLE
fix crash during spi multi insert

### DIFF
--- a/compat10/pglogical_compat.h
+++ b/compat10/pglogical_compat.h
@@ -18,7 +18,13 @@
 
 #define GetCurrentIntegerTimestamp() GetCurrentTimestamp()
 
-#define	PGLDoCopy(stmt, queryString, processed) DoCopy(NULL, stmt, -1, 0, processed)
+#define	PGLDoCopy(stmt, queryString, processed) \
+	do \
+	{ \
+		ParseState* pstate = make_parsestate(NULL); \
+		DoCopy(pstate, stmt, -1, 0, processed); \
+		free_parsestate(pstate); \
+	} while (false);
 
 #define pg_analyze_and_rewrite(parsetree, query_string, paramTypes, numParams) \
 	pg_analyze_and_rewrite(parsetree, query_string, paramTypes, numParams, NULL)

--- a/pglogical_apply_spi.c
+++ b/pglogical_apply_spi.c
@@ -510,8 +510,8 @@ pglogical_proccess_copy(pglogical_copyState *pglcstate)
 	SPI_push();
 
 	/* Initiate the actual COPY */
-	PGLDoCopy((CopyStmt *) linitial(pglcstate->copy_parsetree),
-			  pglcstate->copy_stmt->data, &processed);
+	PGLDoCopy((CopyStmt*)((RawStmt *)linitial(pglcstate->copy_parsetree))->stmt,	
+		pglcstate->copy_stmt->data, &processed);
 
 	/* Clean up SPI state */
 	SPI_pop();


### PR DESCRIPTION
On PG10 a multi-insert with SPI on always leads to a crash. There are two bugs in the code here. One is that the copy_parsetree does not contain CopyStmt pointers directly, but rather has a list of RawStmt which internally have a CopyStmt pointer. Secondly, it is not allowed to pass a NULL value for ParseState to the DoCopy function. Thus, a dummy ParseState must be available.