### PR TITLE
fix for subscription crashed but not restored by manager

### DIFF
--- a/pglogical_manager.c
+++ b/pglogical_manager.c
@@ -98,6 +98,9 @@ manage_apply_workers(void)
 			else
 				prev = wlc;
 		}
+		/* If the subscriber does not have a registered worker. */
+		if (!wlc)
+			apply = NULL;
 
 		/* Skip if the worker was alrady registered. */
 		if (pglogical_worker_running(apply))


### PR DESCRIPTION
Hi,
some times ago i submitted issue #171, now we have found the bug and fixed it. The problem was with workers list: if subscription does not find its own worker, apply remain equal to last element of list.
Let me know

Damiano