### PR TITLE
Fixing a typo in the SQL query

### DIFF
--- a/pglogical_rpc.c
+++ b/pglogical_rpc.c
@@ -74,7 +74,7 @@ pg_logical_get_remote_repset_tables(PGconn *conn, List *replication_sets)
 		/* PGLogical 2.0+ */
 		appendStringInfo(&query,
 						 "SELECT i.relid, i.nspname, i.relname, i.att_list,"
-						 "       i.has_row_filter, i.nspname as i.nsptarget, i.relname as i.reltarget"
+						 "       i.has_row_filter, i.nspname as nsptarget, i.relname as reltarget"
 						 "  FROM (SELECT DISTINCT relid FROM pglogical.tables WHERE set_name = ANY(ARRAY[%s])) t,"
 						 "       LATERAL pglogical.show_repset_table_info(t.relid, ARRAY[%s]) i",
 						 repsetarr.data, repsetarr.data);


### PR DESCRIPTION
«column as t.col» is not valid SQL but «column as col» is...

This should  fix the issue: https://github.com/2ndQuadrant/pglogical/issues/240