### PR TITLE
Relation name is quoted twice

### DIFF
--- a/pglogical_create_subscriber.c
+++ b/pglogical_create_subscriber.c
@@ -490,7 +490,6 @@ main(int argc, char **argv)
 	print_msg(VERBOSITY_VERBOSE,
 			  _("Removing old pglogical configuration ...\n"));
 
-
 	for (dbnum = 0; dbnum < n_databases; dbnum++)
 	{
 		char *db = database_list[dbnum];
@@ -968,7 +967,7 @@ remove_unwanted_data(PGconn *conn)
 	PGresult		   *res;
 
 	/*
-	 * Remove replication identifiers (9.4 will get the removed by dropping
+	 * Remove replication identifiers (9.4 will get them removed by dropping
 	 * the extension later as we emulate them there).
 	 */
 	if (PQserverVersion(conn) >= 90500)
@@ -1088,10 +1087,7 @@ pglogical_subscribe(PGconn *conn, char *subscriber_name, char *subscriber_dsn,
 	PQExpBufferData		repsets;
 	PGresult		   *res;
 
-					  PQescapeLiteral(conn, subscriber_dsn, strlen(subscriber_dsn)),
-
 	initPQExpBuffer(&query);
-
 	printfPQExpBuffer(&query,
 					  "SELECT pglogical.create_node(node_name := %s, dsn := %s);",
 					  PQescapeLiteral(conn, subscriber_name, strlen(subscriber_name)),

--- a/pglogical_rpc.c
+++ b/pglogical_rpc.c
@@ -134,9 +134,7 @@ pg_logical_get_remote_repset_table(PGconn *conn, RangeVar *rv,
 	StringInfoData  relname;
 
 	initStringInfo(&relname);
-	appendStringInfo(&relname, "%s.%s",
-					 PQescapeLiteral(conn, rv->schemaname, strlen(rv->schemaname)),
-					 PQescapeLiteral(conn, rv->relname, strlen(rv->relname)));
+	appendStringInfo(&relname, "%s.%s", rv->schemaname, rv->relname);
 
 	initStringInfo(&repsetarr);
 	foreach (lc, replication_sets)


### PR DESCRIPTION
This bug was reported in issue #249. It is exposed while using different
versions (provider 2.2.x and subscriber 2.3.0).