### PR TITLE
pg_ctl from pglogical_create_subscriber should run in silent mode only when verbosity is off

### DIFF
--- a/pglogical_create_subscriber.c
+++ b/pglogical_create_subscriber.c
@@ -668,7 +668,7 @@ run_pg_ctl(const char *arg)
 	PQExpBuffer  cmd = createPQExpBuffer();
 	char		*exec_path = find_other_exec_or_die(argv0, "pg_ctl");
 
-	appendPQExpBuffer(cmd, "%s %s -D \"%s\" -s", exec_path, arg, data_dir);
+	appendPQExpBuffer(cmd, "%s %s -D \"%s\"", exec_path, arg, data_dir);
 
 	/* Run pg_ctl in silent mode unless we run in debug mode. */
 	if (verbosity < VERBOSITY_DEBUG)


### PR DESCRIPTION
pglogical_create_subscriber executed pg_ctl always in silent mode, even
when verbosity option is set.
This patch will make pg_ctl emit meaningful information in cases where `-v`
is passed to pglogical_create_subscriber, making it wasier to debug issues
where pg_ctl fails

Signed-off-by: Martín Marqués <martin.marques@2ndquadrant.com>