### PR TITLE
Clarify change in pg_hba.conf rules between PostgreSQL 9.6 and Postgres 10.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -178,7 +178,11 @@ you can add this additional option to postgresql.conf:
     track_commit_timestamp = on # needed for last/first update wins conflict resolution
                                 # property available in PostgreSQL 9.5+
 
-`pg_hba.conf` has to allow replication connections from localhost.
+`pg_hba.conf` has to allow logical replication connections from localhost. Up
+until PostgreSQL 9.6 logical replication connections are managed using the
+`replication` keyword in `pg_hba.conf`. In PostgreSQL 10+ logical replication
+connections are treated as regular connections to the provider database by
+`pg_hba.conf`.
 
 Next the `pglogical` extension has to be installed on all nodes:
 


### PR DESCRIPTION
The current quick setup guide just specifies that "`pg_hba.conf` has to allow replication connections from localhost."

The way that Postgres handles _logical_ replication connections in `pg_hba.conf` has changed in recent versions, which could potentially cause confusion for users if they look at documentation for the wrong version of Postgres. Up until Postgres 9.6 both physical and logical replication connections were matched by the `replication` keyword in `pg_hba.conf`, but starting in Postgres 10, logical replication connections are matched based on which database they connect to. This is mentioned in the [release notes](https://www.postgresql.org/docs/10/release-10.html#id-1.11.6.20.4).

I believe clarifying this change of behavior should make it easier for users to setup pglogical.