### PR TITLE
if any "before row triggers" cancels the operation (aka RETURN NULL) …

### DIFF
--- a/pglogical_apply_heap.c
+++ b/pglogical_apply_heap.c
@@ -735,7 +735,6 @@ pglogical_apply_heap_delete(PGLogicalRelation *rel, PGLogicalTupleData *oldtup)
 			{
 				PopActiveSnapshot();
 				finish_apply_exec_state(aestate);
-				pglogical_relation_close(rel, NoLock);
 				return;
 			}
 		}

--- a/pglogical_relcache.c
+++ b/pglogical_relcache.c
@@ -198,6 +198,9 @@ pglogical_relation_cache_updater(PGLogicalRemoteRel *remoterel)
 void
 pglogical_relation_close(PGLogicalRelation * rel, LOCKMODE lockmode)
 {
+	/* is the relation already closed? this shouldn't happen */
+	Assert(rel->rel != NULL);
+
 	table_close(rel->rel, lockmode);
 	rel->rel = NULL;
 }


### PR DESCRIPTION
…then

pglogical_apply_heap_delete() closes the relation but handle_delete()
does not expect that.