### PR TITLE
Fix shared memory size estimation.

### DIFF
--- a/pglogical_worker.c
+++ b/pglogical_worker.c
@@ -649,8 +649,12 @@ pglogical_subscription_changed(Oid subid, bool kill)
 static size_t
 worker_shmem_size(int nworkers)
 {
-	return offsetof(PGLogicalContext, workers) +
-		sizeof(PGLogicalWorker) * nworkers;
+	Size		size;
+
+	size = CACHELINEALIGN(offsetof(PGLogicalContext, workers));
+	size = add_size(size, sizeof(PGLogicalWorker) * nworkers);
+
+	return size;
 }
 
 /*


### PR DESCRIPTION
Hi,

worker_shmem_size() forgot to properly account for worker_shmem_size alignment, which can end up slightly underestimating the amount of shared memory that will be consumed.

As mentioned in https://www.postgresql.org/message-id/20210227080815.jryyhy6lrn6gahkm@nol ShmemAlloc aligns the size with CACHELINEALIGN rather than MAXALIGN since PG96.