### PR TITLE
Fix typo in sync state constant

### DIFF
--- a/pglogical_functions.c
+++ b/pglogical_functions.c
@@ -992,7 +992,7 @@ sync_status_to_string(char status)
 			return "sync_structure";
 		case SYNC_STATUS_DATA:
 			return "sync_data";
-		case SYNC_STATUS_CONSTAINTS:
+		case SYNC_STATUS_CONSTRAINTS:
 			return "sync_constraints";
 		case SYNC_STATUS_SYNCWAIT:
 			return "sync_waiting";

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -881,7 +881,7 @@ pglogical_sync_subscription(PGLogicalSubscription *sub)
 				{
 					elog(INFO, "synchronizing constraints");
 
-					status = SYNC_STATUS_CONSTAINTS;
+					status = SYNC_STATUS_CONSTRAINTS;
 					StartTransactionCommand();
 					set_subscription_sync_status(sub->id, status);
 					CommitTransactionCommand();

--- a/pglogical_sync.h
+++ b/pglogical_sync.h
@@ -44,7 +44,7 @@ typedef struct PGLogicalSyncStatus
 #define SYNC_STATUS_INIT		'i'		/* Ask for sync. */
 #define SYNC_STATUS_STRUCTURE	's'     /* Sync structure */
 #define SYNC_STATUS_DATA		'd'		/* Data sync. */
-#define SYNC_STATUS_CONSTAINTS	'c'		/* Constraint sync (post-data structure). */
+#define SYNC_STATUS_CONSTRAINTS	'c'		/* Constraint sync (post-data structure). */
 #define SYNC_STATUS_SYNCWAIT	'w'		/* Table sync is waiting to get OK from main thread. */
 #define SYNC_STATUS_CATCHUP		'u'		/* Catching up. */
 #define SYNC_STATUS_SYNCDONE	'y'		/* Synchronization finished (at lsn). */


### PR DESCRIPTION
Fix a non-breaking typo in sync state constant `SYNC_STATUS_CONSTRAINTS`.