### PR TITLE
Segmentation fault in regression tests triggers and row_filter with latest Postgres code.

### DIFF
--- a/pglogical_functions.c
+++ b/pglogical_functions.c
@@ -627,8 +627,11 @@ pglogical_drop_subscription(PG_FUNCTION_ARGS)
 			PQfinish(origin_conn);
 		}
 		PG_CATCH();
+		{
+			FlushErrorState();
 			elog(WARNING, "could not drop slot \"%s\" on provider, you will probably have to drop it manually",
 				 sub->slot_name);
+		}
 		PG_END_TRY();
 
 		/* Drop the origin tracking locally. */

--- a/pglogical_output_plugin.c
+++ b/pglogical_output_plugin.c
@@ -28,6 +28,7 @@
 #include "utils/inval.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/snapmgr.h"
 #include "replication/origin.h"
 
 #include "pglogical_output_plugin.h"
@@ -659,6 +660,7 @@ pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 	MemoryContext	old;
 	Bitmapset	   *att_list = NULL;
 
+	PushActiveSnapshot(GetTransactionSnapshot());
 	/* Avoid leaking memory by using and resetting our own context */
 	old = MemoryContextSwitchTo(data->context);
 
@@ -729,6 +731,7 @@ pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 	Assert(CurrentMemoryContext == data->context);
 	MemoryContextSwitchTo(old);
 	MemoryContextReset(data->context);
+	PopActiveSnapshot();
 }
 
 #ifdef HAVE_REPLICATION_ORIGINS


### PR DESCRIPTION
Regression tests triggers and row_filter fails after the postgres commit - https://github.com/postgres/postgres/commit/d18ee6f92d9a22b4fae57f515797b2196bf385c7

**Postgres version used** - latest code from REL_13_STABLE branch 
**Pglogical version** - 2.3.4

[2021-08-05 22:52:09.073 UTC] [14329] [] LOG:  background worker "pglogical apply 14360:3848008564" (PID 14872) was terminated by signal 11: Segmentation fault

**Stack trace with triggers test (Seg fault in subscriber) -**
 
```
Core was generated by postgres: pglogical apply 14360:3848008564                                    '.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000000000079be55 in EnsurePortalSnapshotExists () at pquery.c:1764
1764		portal->portalSnapshot = GetActiveSnapshot();
(gdb) bt
#0  0x000000000079be55 in EnsurePortalSnapshotExists () at pquery.c:1764
#1  0x00007fc97268befe in exec_eval_simple_expr (rettypmod=0x7ffe748ae0ec, rettype=0x7ffe748ae0e8, isNull=0x7ffe748ae1e0, result=<synthetic pointer>, expr=0x45c2288, estate=0x7ffe748ae560)
    at pl_exec.c:6211
#2  exec_eval_expr (estate=0x7ffe748ae560, expr=0x45c2288, isNull=0x7ffe748ae1e0, rettype=0x7ffe748ae0e8, rettypmod=0x7ffe748ae0ec) at pl_exec.c:5861
#3  0x00007fc97268e24b in exec_eval_boolean (estate=estate@entry=0x7ffe748ae560, expr=<optimized out>, isNull=isNull@entry=0x7ffe748ae1e0) at pl_exec.c:5826
#4  0x00007fc97269011e in exec_stmt_if (stmt=0x45ee130, estate=0x7ffe748ae560) at pl_exec.c:2519
#5  exec_stmt (estate=estate@entry=0x7ffe748ae560, stmt=0x45ee130) at pl_exec.c:1997
#6  0x00007fc972692ee5 in exec_stmts (estate=0x7ffe748ae560, stmts=0x45ee180) at pl_exec.c:1944
#7  0x00007fc9726934d0 in exec_stmt_block (estate=estate@entry=0x7ffe748ae560, block=block@entry=0x45ee1d0) at pl_exec.c:1885
#8  0x00007fc972690098 in exec_stmt (estate=estate@entry=0x7ffe748ae560, stmt=0x45ee1d0) at pl_exec.c:1977
#9  0x00007fc972693991 in plpgsql_exec_trigger (func=func@entry=0x45aea38, trigdata=0x7ffe748ae9c0) at pl_exec.c:1027
#10 0x00007fc97269d764 in plpgsql_call_handler (fcinfo=0x7ffe748ae7e0) at pl_handler.c:256
#11 0x0000000000631d6d in ExecCallTriggerFunc (trigdata=trigdata@entry=0x7ffe748ae9c0, tgindx=tgindx@entry=0, finfo=finfo@entry=0x4564438, instr=instr@entry=0x0, 
    per_tuple_context=per_tuple_context@entry=0x45ea9b0) at trigger.c:2084
#12 0x0000000000632a43 in AfterTriggerExecute (trigdesc=0x4564328, trigdesc=0x4564328, trig_tuple_slot2=0x0, trig_tuple_slot1=0x0, per_tuple_context=0x45ea9b0, instr=0x0, finfo=0x4564438, 
    relInfo=0x4562fd8, event=0x45e8ad8, estate=0x45d9898) at trigger.c:3973
#13 afterTriggerInvokeEvents (events=events@entry=0x45ba5d8, firing_id=1, estate=estate@entry=0x45d9898, delete_ok=delete_ok@entry=false) at trigger.c:4189
#14 0x0000000000637d54 in AfterTriggerEndQuery (estate=0x45d9898) at trigger.c:4525
#15 0x00007fc97bf2faa5 in finish_apply_exec_state (aestate=0x4562d68) at pglogical_apply_heap.c:277
#16 0x00007fc97bf2ffe0 in pglogical_apply_heap_insert (rel=0x45a4700, newtup=<optimized out>) at pglogical_apply_heap.c:498
#17 0x00007fc97bf1b7e5 in handle_insert (s=s@entry=0x7ffe748b2d10) at pglogical_apply.c:580
#18 0x00007fc97bf1c582 in replication_handler (s=0x7ffe748b2d10) at pglogical_apply.c:1131
#19 apply_work (streamConn=streamConn@entry=0x45a3520) at pglogical_apply.c:1421
#20 0x00007fc97bf1cfce in pglogical_apply_main (main_arg=<optimized out>) at pglogical_apply.c:1977
#21 0x000000000071d72a in StartBackgroundWorker () at bgworker.c:890
#22 0x0000000000727c22 in do_start_bgworker (rw=0x4514b70) at postmaster.c:5933
```

**Stack trace with row_filter test (Seg fault in provider) -**
 
```
Core was generated by postgres: walsender super [local] idle                                        '.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000000000079be55 in EnsurePortalSnapshotExists () at pquery.c:1764
1764		portal->portalSnapshot = GetActiveSnapshot();
(gdb) bt
#0  0x000000000079be55 in EnsurePortalSnapshotExists () at pquery.c:1764
#1  0x00007f5a39d13efe in exec_eval_simple_expr (rettypmod=0x7fff4642c33c, rettype=0x7fff4642c338, isNull=0x7fff4642c430, result=<synthetic pointer>, expr=0x3ce2318, estate=0x7fff4642c7a0)
    at pl_exec.c:6211
#2  exec_eval_expr (estate=0x7fff4642c7a0, expr=0x3ce2318, isNull=0x7fff4642c430, rettype=0x7fff4642c338, rettypmod=0x7fff4642c33c) at pl_exec.c:5861
#3  0x00007f5a39d1624b in exec_eval_boolean (estate=estate@entry=0x7fff4642c7a0, expr=<optimized out>, isNull=isNull@entry=0x7fff4642c430) at pl_exec.c:5826
#4  0x00007f5a39d1811e in exec_stmt_if (stmt=0x3ce25b0, estate=0x7fff4642c7a0) at pl_exec.c:2519
#5  exec_stmt (estate=estate@entry=0x7fff4642c7a0, stmt=0x3ce25b0) at pl_exec.c:1997
#6  0x00007f5a39d1aee5 in exec_stmts (estate=0x7fff4642c7a0, stmts=0x3ce2600) at pl_exec.c:1944
#7  0x00007f5a39d1b4d0 in exec_stmt_block (estate=estate@entry=0x7fff4642c7a0, block=block@entry=0x3ce2650) at pl_exec.c:1885
#8  0x00007f5a39d18098 in exec_stmt (estate=estate@entry=0x7fff4642c7a0, stmt=0x3ce2650) at pl_exec.c:1977
#9  0x00007f5a39d1aad8 in plpgsql_exec_function (func=func@entry=0x3c16928, fcinfo=fcinfo@entry=0x3cc7ed0, simple_eval_estate=simple_eval_estate@entry=0x0, 
    simple_eval_resowner=simple_eval_resowner@entry=0x0, atomic=<optimized out>) at pl_exec.c:611
#10 0x00007f5a39d25679 in plpgsql_call_handler (fcinfo=0x3cc7ed0) at pl_handler.c:265
#11 0x00000000006509a3 in ExecInterpExpr (state=0x3cc7af0, econtext=0x3ced148, isnull=<optimized out>) at execExprInterp.c:680
#12 0x00007f5a437bd435 in pglogical_change_filter (att_list=<synthetic pointer>, change=0x44e8e78, relation=0x7f5a48fc84b0, data=0x3c0d690) at pglogical_output_plugin.c:634
#13 pg_decode_change (ctx=0x3c0d568, txn=<optimized out>, relation=0x7f5a48fc84b0, change=0x44e8e78) at pglogical_output_plugin.c:666
#14 0x000000000073add3 in change_cb_wrapper (cache=<optimized out>, txn=<optimized out>, relation=<optimized out>, change=<optimized out>) at logical.c:757
#15 0x0000000000743355 in ReorderBufferCommit (rb=0x3ca52a8, xid=xid@entry=1404, commit_lsn=33640808, end_lsn=<optimized out>, commit_time=commit_time@entry=681517650311577, 
    origin_id=origin_id@entry=0, origin_lsn=0) at reorderbuffer.c:1653
#16 0x0000000000738a3c in DecodeCommit (xid=1404, parsed=0x7fff4642ceb0, buf=0x7fff4642d060, ctx=0x3c0d568) at decode.c:637
#17 DecodeXactOp (ctx=0x3c0d568, buf=buf@entry=0x7fff4642d060) at decode.c:245
#18 0x0000000000738d89 in LogicalDecodingProcessRecord (ctx=0x3c0d568, record=0x3c0d800) at decode.c:114
#19 0x0000000000759942 in XLogSendLogical () at walsender.c:3001
#20 0x000000000075b237 in WalSndLoop (send_data=send_data@entry=0x759900 <XLogSendLogical>) at walsender.c:2429
#21 0x000000000075bfc4 in StartLogicalReplication (cmd=0x3caddf8) at walsender.c:1237
#22 exec_replication_command (
    cmd_string=cmd_string@entry=0x3be3c38 "START_REPLICATION SLOT \"pgl_postgres_test_provider_test_sube55bf37\" LOGICAL 0/1D83670 (expected_encoding 'SQL_ASCII', min_proto_version '1', max_proto_version '1', startup_params_format '1', \"binary.w"...) at walsender.c:1764
#23 0x0000000000798ae0 in PostgresMain (argc=<optimized out>, argv=argv@entry=0x3c150c8, dbname=<optimized out>, username=<optimized out>) at postgres.c:4339
#24 0x00000000004c93af in BackendRun (port=0x3c0a720, port=0x3c0a720) at postmaster.c:4589
#25 BackendStartup (port=0x3c0a720) at postmaster.c:4273
#26 ServerLoop () at postmaster.c:1802
#27 0x000000000072997c in PostmasterMain (argc=argc@entry=8, argv=argv@entry=0x3bdf7d0) at postmaster.c:1475
#28 0x00000000004ca682 in main (argc=8, argv=0x3bdf7d0) at main.c:210
```

I'm able to reproduce it manually also, just setup basic pglogical connection, then followed the Sqls in triggers.sql test up until line 62 - https://github.com/2ndQuadrant/pglogical/blob/REL2_3_4/sql/triggers.sql#L62 
Provider hangs after it and subscriber keeps on segfaulting. 

I have tested pglogical with postgres 13.3 also (commit mentioned above was made after 13.3 release), no issue - all regressions tests passed. 
Found that logical replication in postgres also failed with similar stack trace - https://www.postgresql.org/message-id/flat/B4A3AF82-79ED-4F4C-A4E5-CD2622098972%40enterprisedb.com
But this is already fixed by the community - https://github.com/postgres/postgres/commit/6e43f1c2df3da18b9d7087edddaf72dec84cfaf4

I have done similar changes in pglogical code as above community change, which fixes the segmentation fault and all regression tests passes. 

This patch fixes the issue that is exposed by https://github.com/postgres/postgres/commit/d18ee6f92d9a22b4fae57f515797b2196bf385c7