### PR TITLE
Snapshot is still active warning

### DIFF
--- a/pglogical_apply_heap.c
+++ b/pglogical_apply_heap.c
@@ -541,8 +541,6 @@ pglogical_apply_heap_update(PGLogicalRelation *rel, PGLogicalTupleData *oldtup,
 	ExecSetSlotDescriptor(localslot, RelationGetDescr(rel->rel));
 #endif
 
-	PushActiveSnapshot(GetTransactionSnapshot());
-
 	/* Search for existing tuple with same key */
 	found = pglogical_tuple_find_replidx(aestate->resultRelInfo, oldtup, localslot,
 										 &replident_idx_id);
@@ -729,8 +727,6 @@ pglogical_apply_heap_delete(PGLogicalRelation *rel, PGLogicalTupleData *oldtup)
 	localslot = ExecInitExtraTupleSlot(aestate->estate);
 	ExecSetSlotDescriptor(localslot, RelationGetDescr(rel->rel));
 #endif
-
-	PushActiveSnapshot(GetTransactionSnapshot());
 
 	if (pglogical_tuple_find_replidx(aestate->resultRelInfo, oldtup, localslot,
 									 &replident_idx_id))


### PR DESCRIPTION
Commit 17a83481661e531669d6904920a9109424fa3339 moved `PushActiveSnapshot()` into `init_apply_exec_state()` but forgot to remove it from `pglogical_apply_heap_update()` and `pglogical_apply_heap_delete()`.

Fix issue #336.