### PR TITLE
Snapshot handling fixes

### DIFF
--- a/expected/functions.out
+++ b/expected/functions.out
@@ -369,6 +369,56 @@ SELECT * FROM public.not_nullcheck_tbl;
 (2 rows)
 
 \c :provider_dsn
+SELECT pglogical.replicate_ddl_command($$
+CREATE FUNCTION public.some_prime_numbers() RETURNS SETOF integer
+	LANGUAGE sql IMMUTABLE STRICT LEAKPROOF
+	AS $_$
+  VALUES (2), (3), (5), (7), (11), (13), (17), (19), (23), (29), (31), (37), (41), (43), (47), (53), (59), (61), (67), (71), (73), (79), (83), (89), (97)
+$_$;
+
+CREATE FUNCTION public.is_prime_lt_100(integer) RETURNS boolean
+    LANGUAGE sql IMMUTABLE STRICT LEAKPROOF
+	AS $_$
+  SELECT EXISTS (SELECT FROM public.some_prime_numbers() s(p) WHERE p = $1)
+$_$;
+
+CREATE DOMAIN public.prime AS integer
+CONSTRAINT prime_check CHECK(public.is_prime_lt_100(VALUE));
+
+CREATE TABLE public.prime_tbl (
+	num public.prime NOT NULL,
+	PRIMARY KEY(num)
+);
+
+INSERT INTO public.prime_tbl (num) VALUES(17), (31), (79);
+$$);
+ replicate_ddl_command 
+-----------------------
+ t
+(1 row)
+
+SELECT * FROM pglogical.replication_set_add_table('default', 'public.prime_tbl');
+ replication_set_add_table 
+---------------------------
+ t
+(1 row)
+
+DELETE FROM public.prime_tbl WHERE num = 31;
+SELECT pglogical.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT num FROM public.prime_tbl;
+ num 
+-----
+  17
+  79
+(2 rows)
+
+\c :provider_dsn
 \set VERBOSITY terse
 SELECT pglogical.replicate_ddl_command($$
 	DROP TABLE public.funct CASCADE;
@@ -379,12 +429,17 @@ SELECT pglogical.replicate_ddl_command($$
 	DROP FUNCTION public.add(integer, integer);
 	DROP TABLE public.nullcheck_tbl CASCADE;
 	DROP TABLE public.not_nullcheck_tbl CASCADE;
+	DROP TABLE public.prime_tbl CASCADE;
+	DROP DOMAIN public.prime;
+	DROP FUNCTION public.is_prime_lt_100(integer);
+	DROP FUNCTION public.some_prime_numbers();
 $$);
 NOTICE:  drop cascades to table public.funct membership in replication set default_insert_only
 NOTICE:  drop cascades to table public.funct2 membership in replication set default_insert_only
 NOTICE:  drop cascades to table public.funct5 membership in replication set default_insert_only
 NOTICE:  drop cascades to table public.nullcheck_tbl membership in replication set default
 NOTICE:  drop cascades to table public.not_nullcheck_tbl membership in replication set default
+NOTICE:  drop cascades to table public.prime_tbl membership in replication set default
  replicate_ddl_command 
 -----------------------
  t

--- a/expected/functions_1.out
+++ b/expected/functions_1.out
@@ -369,6 +369,56 @@ SELECT * FROM public.not_nullcheck_tbl;
 (2 rows)
 
 \c :provider_dsn
+SELECT pglogical.replicate_ddl_command($$
+CREATE FUNCTION public.some_prime_numbers() RETURNS SETOF integer
+	LANGUAGE sql IMMUTABLE STRICT LEAKPROOF
+	AS $_$
+  VALUES (2), (3), (5), (7), (11), (13), (17), (19), (23), (29), (31), (37), (41), (43), (47), (53), (59), (61), (67), (71), (73), (79), (83), (89), (97)
+$_$;
+
+CREATE FUNCTION public.is_prime_lt_100(integer) RETURNS boolean
+    LANGUAGE sql IMMUTABLE STRICT LEAKPROOF
+	AS $_$
+  SELECT EXISTS (SELECT FROM public.some_prime_numbers() s(p) WHERE p = $1)
+$_$;
+
+CREATE DOMAIN public.prime AS integer
+CONSTRAINT prime_check CHECK(public.is_prime_lt_100(VALUE));
+
+CREATE TABLE public.prime_tbl (
+	num public.prime NOT NULL,
+	PRIMARY KEY(num)
+);
+
+INSERT INTO public.prime_tbl (num) VALUES(17), (31), (79);
+$$);
+ replicate_ddl_command 
+-----------------------
+ t
+(1 row)
+
+SELECT * FROM pglogical.replication_set_add_table('default', 'public.prime_tbl');
+ replication_set_add_table 
+---------------------------
+ t
+(1 row)
+
+DELETE FROM public.prime_tbl WHERE num = 31;
+SELECT pglogical.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT num FROM public.prime_tbl;
+ num 
+-----
+  17
+  79
+(2 rows)
+
+\c :provider_dsn
 \set VERBOSITY terse
 SELECT pglogical.replicate_ddl_command($$
 	DROP TABLE public.funct CASCADE;
@@ -379,12 +429,17 @@ SELECT pglogical.replicate_ddl_command($$
 	DROP FUNCTION public.add(integer, integer);
 	DROP TABLE public.nullcheck_tbl CASCADE;
 	DROP TABLE public.not_nullcheck_tbl CASCADE;
+	DROP TABLE public.prime_tbl CASCADE;
+	DROP DOMAIN public.prime;
+	DROP FUNCTION public.is_prime_lt_100(integer);
+	DROP FUNCTION public.some_prime_numbers();
 $$);
 NOTICE:  drop cascades to table public.funct membership in replication set default_insert_only
 NOTICE:  drop cascades to table public.funct2 membership in replication set default_insert_only
 NOTICE:  drop cascades to table public.funct5 membership in replication set default_insert_only
 NOTICE:  drop cascades to table public.nullcheck_tbl membership in replication set default
 NOTICE:  drop cascades to table public.not_nullcheck_tbl membership in replication set default
+NOTICE:  drop cascades to table public.prime_tbl membership in replication set default
  replicate_ddl_command 
 -----------------------
  t

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -531,6 +531,8 @@ handle_insert(StringInfo s)
 	PGLogicalRelation  *rel;
 	bool				started_tx = ensure_transaction();
 
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	errcallback_arg.action_name = "INSERT";
 	xact_action_counter++;
 
@@ -541,6 +543,8 @@ handle_insert(StringInfo s)
 	if (!should_apply_changes_for_rel(rel->nspname, rel->relname))
 	{
 		pglogical_relation_close(rel, NoLock);
+		PopActiveSnapshot();
+		CommandCounterIncrement();
 		return;
 	}
 
@@ -596,6 +600,9 @@ handle_insert(StringInfo s)
 		LockRelationIdForSession(&lockid, RowExclusiveLock);
 		pglogical_relation_close(rel, NoLock);
 
+		PopActiveSnapshot();
+		CommandCounterIncrement();
+
 		apply_api.on_commit();
 
 		handle_queued_message(ht, started_tx);
@@ -615,7 +622,12 @@ handle_insert(StringInfo s)
 //			CommitTransactionCommand();
 	}
 	else
+	{
 		pglogical_relation_close(rel, NoLock);
+
+		PopActiveSnapshot();
+		CommandCounterIncrement();
+	}
 }
 
 static void
@@ -654,6 +666,8 @@ handle_update(StringInfo s)
 
 	multi_insert_finish();
 
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	rel = pglogical_read_update(s, RowExclusiveLock, &hasoldtup, &oldtup,
 								&newtup);
 	errcallback_arg.rel = rel;
@@ -662,12 +676,17 @@ handle_update(StringInfo s)
 	if (!should_apply_changes_for_rel(rel->nspname, rel->relname))
 	{
 		pglogical_relation_close(rel, NoLock);
+		PopActiveSnapshot();
+		CommandCounterIncrement();
 		return;
 	}
 
 	apply_api.do_update(rel, hasoldtup ? &oldtup : &newtup, &newtup);
 
 	pglogical_relation_close(rel, NoLock);
+
+	PopActiveSnapshot();
+	CommandCounterIncrement();
 }
 
 static void
@@ -683,6 +702,8 @@ handle_delete(StringInfo s)
 
 	multi_insert_finish();
 
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	rel = pglogical_read_delete(s, RowExclusiveLock, &oldtup);
 	errcallback_arg.rel = rel;
 
@@ -690,12 +711,17 @@ handle_delete(StringInfo s)
 	if (!should_apply_changes_for_rel(rel->nspname, rel->relname))
 	{
 		pglogical_relation_close(rel, NoLock);
+		PopActiveSnapshot();
+		CommandCounterIncrement();
 		return;
 	}
 
 	apply_api.do_delete(rel, &oldtup);
 
 	pglogical_relation_close(rel, NoLock);
+
+	PopActiveSnapshot();
+	CommandCounterIncrement();
 }
 
 inline static bool

--- a/pglogical_apply_heap.c
+++ b/pglogical_apply_heap.c
@@ -257,8 +257,6 @@ init_apply_exec_state(PGLogicalRelation *rel)
 {
 	ApplyExecState	   *aestate = palloc0(sizeof(ApplyExecState));
 
-	PushActiveSnapshot(GetTransactionSnapshot());
-
 	/* Initialize the executor state. */
 	aestate->estate = create_estate_for_relation(rel->rel, true);
 
@@ -303,8 +301,6 @@ finish_apply_exec_state(ApplyExecState *aestate)
 	/* Free the memory. */
 	FreeExecutorState(aestate->estate);
 	pfree(aestate);
-
-	PopActiveSnapshot();
 }
 
 /*


### PR DESCRIPTION
Per issue #343, pglogical2 should obtain a snapshot before reading a tuple. That's because a machinery could expect an active snapshot to execute some code (see new test case) before actually inserting the row. Rearrange PushActiveSnapshot and PopActiveSnapshot calls to cover those cases too. It seems the previous commits
(17a83481661e531669d6904920a9109424fa3339 and bd2e972dca9a9fdb7a5ae88f41780fc24ade8632) didn't consider this case.

This bug affects all supported Postgres versions.

Fix issue #343.