### PR TITLE
Reset pglogical.depend OID cache

### DIFF
--- a/pglogical_apply_heap.c
+++ b/pglogical_apply_heap.c
@@ -541,8 +541,6 @@ pglogical_apply_heap_update(PGLogicalRelation *rel, PGLogicalTupleData *oldtup,
 	ExecSetSlotDescriptor(localslot, RelationGetDescr(rel->rel));
 #endif
 
-	PushActiveSnapshot(GetTransactionSnapshot());
-
 	/* Search for existing tuple with same key */
 	found = pglogical_tuple_find_replidx(aestate->resultRelInfo, oldtup, localslot,
 										 &replident_idx_id);
@@ -729,8 +727,6 @@ pglogical_apply_heap_delete(PGLogicalRelation *rel, PGLogicalTupleData *oldtup)
 	localslot = ExecInitExtraTupleSlot(aestate->estate);
 	ExecSetSlotDescriptor(localslot, RelationGetDescr(rel->rel));
 #endif
-
-	PushActiveSnapshot(GetTransactionSnapshot());
 
 	if (pglogical_tuple_find_replidx(aestate->resultRelInfo, oldtup, localslot,
 									 &replident_idx_id))

--- a/pglogical_dependency.c
+++ b/pglogical_dependency.c
@@ -132,6 +132,8 @@ typedef FormData_pglogical_depend *Form_pglogical_depend;
 #define Anum_pglogical_depend_refobjsubid	6
 #define Anum_pglogical_depend_deptype		7
 
+Oid	pglogical_depend_oid = InvalidOid;	/* cache pglogical.depend OID */
+
 static Oid
 get_pglogical_depend_rel_oid(void);
 
@@ -2071,12 +2073,10 @@ doDeletion(const ObjectAddress *object)
 static Oid
 get_pglogical_depend_rel_oid(void)
 {
-	static Oid	dependrelationoid = InvalidOid;
+	if (pglogical_depend_oid == InvalidOid)
+		pglogical_depend_oid = get_pglogical_table_oid(CATALOG_REPSET_RELATION);
 
-	if (dependrelationoid == InvalidOid)
-		dependrelationoid = get_pglogical_table_oid(CATALOG_REPSET_RELATION);
-
-	return dependrelationoid;
+	return pglogical_depend_oid;
 }
 
 

--- a/pglogical_dependency.h
+++ b/pglogical_dependency.h
@@ -13,6 +13,8 @@
 #ifndef PGLOGICAL_DEPENDENCY_H
 #define PGLOGICAL_DEPENDENCY_H
 
+extern Oid	pglogical_depend_oid;
+
 extern void pglogical_recordDependencyOn(const ObjectAddress *depender,
 				   const ObjectAddress *referenced,
 				   DependencyType behavior);

--- a/pglogical_executor.c
+++ b/pglogical_executor.c
@@ -293,7 +293,12 @@ pglogical_object_access(ObjectAccessType access,
 		if (classId == ExtensionRelationId &&
 			objectId == get_extension_oid(EXTENSION_NAME, true) &&
 			objectId != InvalidOid /* Should not happen but check anyway */)
+		{
 			dropping_pglogical_obj = true;
+
+			/* reset pglogical.depend OID cache */
+			pglogical_depend_oid = InvalidOid;
+		}
 
 		/* Dropping relation within pglogical? */
 		if (classId == RelationRelationId)


### PR DESCRIPTION
When you drop and create the pglogical extension after previously using
a pglogical function, there could be some function call that will
reference a pglogical.depend OID from the previous pglogical extension
(before dropping the pglogical extension). See the test case in issue

Replace the static variable with a global variable and reset it after
dropping the extension.

Fix issue #347