### PR TITLE
Remove files left from a previous build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ EXTRA_CLEAN += compat94/pglogical_compat.o compat95/pglogical_compat.o \
 			   compat11/pglogical_compat.o compat11/pglogical_compat.bc \
 			   compat12/pglogical_compat.o compat12/pglogical_compat.bc \
 			   compat13/pglogical_compat.o compat13/pglogical_compat.bc \
+			   compat14/pglogical_compat.o compat14/pglogical_compat.bc \
 			   pglogical_create_subscriber.o
 
 # The # in #define is taken as a comment, per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=142043


### PR DESCRIPTION
If you are using the same source code to build with multiple Postgres versions, a previous build (that didn't execute 'make clean') could possibly left an object file and LLVM bitcode file.

This commit is similar to bfa50453d65a1ee63406dc2e87b629e400391648. It handles files created by a v14 build.