### PR TITLE
Setup signal handler before we unblock signals

### DIFF
--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1887,9 +1887,6 @@ pglogical_apply_main(Datum main_arg)
 	Assert(MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_APPLY);
 	MyApplyWorker = &MyPGLogicalWorker->worker.apply;
 
-	/* Establish signal handlers. */
-	pqsignal(SIGTERM, handle_sigterm);
-
 	/* Attach to dsm segment. */
 	Assert(CurrentResourceOwner == NULL);
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "pglogical apply");

--- a/pglogical_manager.c
+++ b/pglogical_manager.c
@@ -200,9 +200,6 @@ pglogical_manager_main(Datum main_arg)
 	/* Setup shmem. */
 	pglogical_worker_attach(slot, PGLOGICAL_WORKER_MANAGER);
 
-	/* Establish signal handlers. */
-	pqsignal(SIGTERM, handle_sigterm);
-
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "pglogical manager");
 
 	StartTransactionCommand();

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -1192,9 +1192,6 @@ pglogical_sync_main(Datum main_arg)
 	MySyncWorker = &MyPGLogicalWorker->worker.sync;
 	MyApplyWorker = &MySyncWorker->apply;
 
-	/* Establish signal handlers. */
-	pqsignal(SIGTERM, handle_sigterm);
-
 	/* Attach to dsm segment. */
 	Assert(CurrentResourceOwner == NULL);
 	CurrentResourceOwner = ResourceOwnerCreate(NULL, "pglogical sync");


### PR DESCRIPTION
The default SIGTERM signal handler implemented by Postgres for
background worker processes throws a FATAL error in the handler itself.
This is not in sync with rest of the system where we generally process
signals out-of-line. This is important because the process might be in a
middle of updating shared memory or holding a spinlock and if the
process exits without a clean state, may lead to issues.

One of our customers reported a "Stuck spinlock" PANIC, which was
tracked down to this. While it might be a good idea to fix the default
signal handler in Postgres, for now, work it around by setting up our
handler before we unblock the signals. This is how other processes work
and is the right thing to do.