### PR TITLE
Make sure we use a correctly deformed tuple when doing initial sync.

### DIFF
--- a/expected/row_filter.out
+++ b/expected/row_filter.out
@@ -18,6 +18,15 @@ $$);
 
 -- used to check if initial copy does row filtering
 \COPY basic_dml(id, other, data, "SomeThing") FROM STDIN WITH CSV
+-- PR #387
+SELECT pglogical.replicate_ddl_command($$
+  ALTER TABLE public.basic_dml ADD COLUMN other2 text DEFAULT 'pr387';
+$$);
+ replicate_ddl_command 
+-----------------------
+ t
+(1 row)
+
 -- create some functions:
 CREATE FUNCTION funcn_add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
@@ -150,12 +159,12 @@ SELECT pglogical.wait_for_subscription_sync_complete('test_subscription');
 (1 row)
 
 COMMIT;
-SELECT id, other, data, "SomeThing" FROM basic_dml ORDER BY id;
-  id  | other | data | SomeThing 
-------+-------+------+-----------
- 5000 |     1 | aaa  | @ 1 hour
- 5002 |     3 | ccc  | @ 3 mins
- 5003 |     4 | ddd  | @ 4 days
+SELECT id, other, data, "SomeThing", other2 FROM basic_dml ORDER BY id;
+  id  | other | data | SomeThing | other2 
+------+-------+------+-----------+--------
+ 5000 |     1 | aaa  | @ 1 hour  | pr387
+ 5002 |     3 | ccc  | @ 3 mins  | pr387
+ 5003 |     4 | ddd  | @ 4 days  | pr387
 (3 rows)
 
 ALTER TABLE public.basic_dml ADD COLUMN subonly integer;

--- a/expected/row_filter_1.out
+++ b/expected/row_filter_1.out
@@ -18,6 +18,15 @@ $$);
 
 -- used to check if initial copy does row filtering
 \COPY basic_dml(id, other, data, "SomeThing") FROM STDIN WITH CSV
+-- PR #387
+SELECT pglogical.replicate_ddl_command($$
+  ALTER TABLE public.basic_dml ADD COLUMN other2 text DEFAULT 'pr387';
+$$);
+ replicate_ddl_command 
+-----------------------
+ t
+(1 row)
+
 -- create some functions:
 CREATE FUNCTION funcn_add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
@@ -150,12 +159,12 @@ SELECT pglogical.wait_for_subscription_sync_complete('test_subscription');
 (1 row)
 
 COMMIT;
-SELECT id, other, data, "SomeThing" FROM basic_dml ORDER BY id;
-  id  | other | data | SomeThing 
-------+-------+------+-----------
- 5000 |     1 | aaa  | @ 1 hour
- 5002 |     3 | ccc  | @ 3 mins
- 5003 |     4 | ddd  | @ 4 days
+SELECT id, other, data, "SomeThing", other2 FROM basic_dml ORDER BY id;
+  id  | other | data | SomeThing | other2 
+------+-------+------+-----------+--------
+ 5000 |     1 | aaa  | @ 1 hour  | pr387
+ 5002 |     3 | ccc  | @ 3 mins  | pr387
+ 5003 |     4 | ddd  | @ 4 days  | pr387
 (3 rows)
 
 ALTER TABLE public.basic_dml ADD COLUMN subonly integer;

--- a/sql/row_filter.sql
+++ b/sql/row_filter.sql
@@ -21,6 +21,11 @@ $$);
 5003,4,ddd,4 days
 \.
 
+-- PR #387
+SELECT pglogical.replicate_ddl_command($$
+  ALTER TABLE public.basic_dml ADD COLUMN other2 text DEFAULT 'pr387';
+$$);
+
 -- create some functions:
 CREATE FUNCTION funcn_add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
@@ -78,7 +83,7 @@ SET LOCAL statement_timeout = '10s';
 SELECT pglogical.wait_for_subscription_sync_complete('test_subscription');
 COMMIT;
 
-SELECT id, other, data, "SomeThing" FROM basic_dml ORDER BY id;
+SELECT id, other, data, "SomeThing", other2 FROM basic_dml ORDER BY id;
 
 ALTER TABLE public.basic_dml ADD COLUMN subonly integer;
 ALTER TABLE public.basic_dml ADD COLUMN subonly_def integer DEFAULT 99;


### PR DESCRIPTION
Currently, this test case will produce a wrong set of data, when calling
table_data_filtered() like we do for an initial table sync:

```
CREATE EXTENSION IF NOT EXISTS pglogical;
CREATE TABLE bar(id bigint primary key);
INSERT INTO bar SELECT t.id FROM generate_series(1, 10) AS t(id);

SELECT * FROM bar;

ALTER TABLE bar ADD COLUMN value TEXT DEFAULT 'me';

SELECT * FROM bar;

COPY (SELECT * FROM pglogical.table_data_filtered(NULL::"public"."bar",
'"public"."bar"'::regclass, ARRAY['default'])) TO stdout;
```

Instead of the correct value 'me', a NULL value will be returned.