### PR TITLE
Optionally skip executing DDL locally in replicate_ddl_command

### DIFF
--- a/pglogical--2.4.1.sql
+++ b/pglogical--2.4.1.sql
@@ -210,7 +210,7 @@ CREATE TABLE pglogical.queue (
     message json NOT NULL
 );
 
-CREATE FUNCTION pglogical.replicate_ddl_command(command text, replication_sets text[] DEFAULT '{ddl_sql}')
+CREATE FUNCTION pglogical.replicate_ddl_command(command text, replication_sets text[] DEFAULT '{ddl_sql}', execute_locally boolean DEFAULT true)
 RETURNS boolean STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'pglogical_replicate_ddl_command';
 
 CREATE OR REPLACE FUNCTION pglogical.queue_truncate()

--- a/pglogical_functions.c
+++ b/pglogical_functions.c
@@ -1754,6 +1754,7 @@ Datum
 pglogical_replicate_ddl_command(PG_FUNCTION_ARGS)
 {
 	text	   *command = PG_GETARG_TEXT_PP(0);
+	bool 	   execute_locally = PG_GETARG_BOOL(2);
 	char	   *query = text_to_cstring(command);
 	int			save_nestlevel;
 	List	   *replication_sets;
@@ -1807,13 +1808,15 @@ pglogical_replicate_ddl_command(PG_FUNCTION_ARGS)
 	 */
 	in_pglogical_replicate_ddl_command = true;
 	PG_TRY();
-	{
-		pglogical_execute_sql_command(query, GetUserNameFromId(GetUserId()
-	#if PG_VERSION_NUM >= 90500
-															   , false
-	#endif
-															   ),
-									  false);
+	if (execute_locally) {
+		{
+			pglogical_execute_sql_command(query, GetUserNameFromId(GetUserId()
+		#if PG_VERSION_NUM >= 90500
+																   , false
+		#endif
+																   ),
+										  false);
+		}
 	}
 	PG_CATCH();
 	{


### PR DESCRIPTION
2nd Quadrant,

We have a use case where we don't want `replicate_ddl_command` to execute locally. Our custom event triggers are capturing all DDL and then call `replicate_ddl_command`. This fails because the DDL is being executed twice - once by the SQL statement itself, and once by `replicate_ddl_command` in the event trigger.

This change adds an `execute_locally` argument in `replicate_ddl_command` that defaults to true for backwards compatibility. I verified this works like I would expect it to in both cases, but if there are greater impacts under the hood that I'm not seeing please let me know. I only knew enough C to make this minor change and have not made contributions to other open source projects so this is a bit of a first for me.