### PR TITLE
Drop database never completes in Postgres 15

### DIFF
--- a/pglogical.c
+++ b/pglogical.c
@@ -694,6 +694,8 @@ pglogical_supervisor_main(Datum main_arg)
     {
 		int rc;
 
+		CHECK_FOR_INTERRUPTS();
+
 		if (PGLogicalCtx->subscriptions_changed)
 		{
 			/*


### PR DESCRIPTION
Postgres 15 introduced a signal barrier for DROP DATABASE (4eb2176318d0561846c1f9fb3c68bede799d640f). pglogical has no logic to handle it in the supervisor code. Add CFI to fix it.

Fix #399