### PR TITLE
Fix building against Postgres 9.6

### DIFF
--- a/compat96/pglogical_compat.c
+++ b/compat96/pglogical_compat.c
@@ -88,3 +88,37 @@ CatalogTupleDelete(Relation heapRel, ItemPointer tid)
 {
 	simple_heap_delete(heapRel, tid);
 }
+
+/*
+ * Copied wholesale from Postgres source since it's declared static
+ * there until 10.2.
+ *
+ * Alternate version that allows caller to specify the elevel for any
+ * error report.  If elevel < ERROR, returns NULL on any error.
+ */
+struct dirent *
+ReadDirExtended(DIR *dir, const char *dirname, int elevel)
+{
+        struct dirent *dent;
+
+        /* Give a generic message for AllocateDir failure, if caller didn't */
+        if (dir == NULL)
+        {
+                ereport(elevel,
+                                (errcode_for_file_access(),
+                                 errmsg("could not open directory \"%s\": %m",
+                                                dirname)));
+                return NULL;
+        }
+
+        errno = 0;
+        if ((dent = readdir(dir)) != NULL)
+                return dent;
+
+        if (errno)
+                ereport(elevel,
+                                (errcode_for_file_access(),
+                                 errmsg("could not read directory \"%s\": %m",
+                                                dirname)));
+        return NULL;
+}

--- a/compat96/pglogical_compat.h
+++ b/compat96/pglogical_compat.h
@@ -33,6 +33,8 @@ extern Oid CatalogTupleInsert(Relation heapRel, HeapTuple tup);
 extern void CatalogTupleUpdate(Relation heapRel, ItemPointer otid, HeapTuple tup);
 extern void CatalogTupleDelete(Relation heapRel, ItemPointer tid);
 
+extern struct dirent * ReadDirExtended(DIR *dir, const char *dirname, int elevel);
+
 /*
  * nowait=true is the standard behavior.  If nowait=false is called,
  * we ignore that, meaning we don't wait even if the caller asked to


### PR DESCRIPTION
The root cause here appears to be that `ReadDirExtended` in Postgres core is defined as `static` up until PG10.2. At that point it's available publicly.

There seems to be some confusion on previous issues reported on this repo: in #227 @petere says "You need at least PostgreSQL 10.2." -- presumably in context he must mean "to use 10.x you need at least 10.2" since the compat9{4,5,6} directories clearly imply the intent to support versions prior to 10. Later in #275 @petere says "pglogical 2.3.2 builds correct against PostgreSQL 9.5." -- but I don't see how this can be the case given this function is used but not available in the public API.

Here I've copied the function directly from Postgres core (but without the static declaration) to support the usage in this project.