### PR TITLE
Fix missing restore of memory context in pg_decode_change()

### DIFF
--- a/pglogical_output_plugin.c
+++ b/pglogical_output_plugin.c
@@ -669,7 +669,7 @@ pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 
 	/* First check the table filter */
 	if (!pglogical_change_filter(data, relation, change, &att_list))
-		return;
+		goto cleanup;
 
 	/*
 	 * If the protocol wants to write relation information and the client
@@ -730,7 +730,7 @@ pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 			Assert(false);
 	}
 
-	/* Cleanup */
+cleanup:
 	Assert(CurrentMemoryContext == data->context);
 	MemoryContextSwitchTo(old);
 	MemoryContextReset(data->context);


### PR DESCRIPTION
Change c53a83c22a29d71ded6316e02a21fc1c84c9f60a forgot to include cleanup for early exit case. Fixes #419