### PR TITLE
resolve additional deadlock during drop database :: pglogical_apply.c :: CHECK_FOR_INTERRUPTS()

### DIFF
--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1360,6 +1360,8 @@ apply_work(PGconn *streamConn)
 	{
 		int			rc;
 		int			r;
+		
+		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:


### PR DESCRIPTION
this was tested on top of: `PostgreSQL-15.3` + `pglogical-2.4.3`

resolve additional deadlock during `drop database`:
fix #418
fix #399

solution for the deadlock in `pglogical_apply_main()` 
is  identical to the solution for the deadlock in `pglogical_supervisor_main()`:
https://github.com/2ndQuadrant/pglogical/pull/403
