### PR TITLE
Postgres 16 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ EXTRA_CLEAN += compat94/pglogical_compat.o compat95/pglogical_compat.o \
 			   compat13/pglogical_compat.o compat13/pglogical_compat.bc \
 			   compat14/pglogical_compat.o compat14/pglogical_compat.bc \
 			   compat15/pglogical_compat.o compat15/pglogical_compat.bc \
+			   compat16/pglogical_compat.o compat16/pglogical_compat.bc \
 			   pglogical_create_subscriber.o
 
 # The # in #define is taken as a comment, per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=142043

--- a/compat10/pglogical_compat.h
+++ b/compat10/pglogical_compat.h
@@ -111,4 +111,6 @@ replorigin_drop_by_name(char *name, bool missing_ok, bool nowait)
 		replorigin_drop(originid, nowait);
 }
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/compat11/pglogical_compat.h
+++ b/compat11/pglogical_compat.h
@@ -125,4 +125,6 @@ replorigin_drop_by_name(char *name, bool missing_ok, bool nowait)
 		replorigin_drop(originid, nowait);
 }
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/compat12/pglogical_compat.h
+++ b/compat12/pglogical_compat.h
@@ -110,4 +110,6 @@ replorigin_drop_by_name(char *name, bool missing_ok, bool nowait)
 		replorigin_drop(originid, nowait);
 }
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/compat13/pglogical_compat.h
+++ b/compat13/pglogical_compat.h
@@ -102,4 +102,6 @@ replorigin_drop_by_name(char *name, bool missing_ok, bool nowait)
 		replorigin_drop(originid, nowait);
 }
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/compat14/pglogical_compat.h
+++ b/compat14/pglogical_compat.h
@@ -93,4 +93,6 @@
 /* 2a10fdc4307a667883f7a3369cb93a721ade9680 */
 #define getObjectDescription(object) getObjectDescription(object, false)
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/compat16/pglogical_compat.c
+++ b/compat16/pglogical_compat.c
@@ -1,0 +1,12 @@
+/*-------------------------------------------------------------------------
+ *
+ * pglogical_compat.c
+ *              compatibility functions (mainly with different PG versions)
+ *
+ * Copyright (c) 2015, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *              pglogical_compat.c
+ *
+ *-------------------------------------------------------------------------
+ */

--- a/compat16/pglogical_compat.h
+++ b/compat16/pglogical_compat.h
@@ -33,7 +33,7 @@
  * handles the stock Pg11 change.
  */ 
 #define ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple) \
- 	ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, NULL)
+	ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, NULL, NULL, NULL)
 
 #undef ExecEvalExpr
 #define ExecEvalExpr(expr, econtext, isNull, isDone) \
@@ -54,7 +54,7 @@
 	ExecARDeleteTriggers(estate, relinfo, tupleid, fdw_trigtuple, NULL, false)
 
 #define ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot) \
-	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot, NULL)
+	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot, NULL, NULL)
 
 #define makeDefElem(name, arg) makeDefElem(name, arg, -1)
 
@@ -99,6 +99,15 @@
 /* e997a0c642860a96df0151cbeccfecbdf0450d08 */
 #define GetFlushRecPtr() GetFlushRecPtr(NULL)
 
-#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+/* 216a784829c2c5f03ab0c43e009126cbb819e9b2 */
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node, 0)
+
+/* 19d8e2308bc51ec4ab993ce90077342c915dd116 */
+#define ExecInsertIndexTuples(resultRelInfo, slot, estate, update, noDupErr, specConflict, arbiterIndexes) \
+	ExecInsertIndexTuples(resultRelInfo, slot, estate, update, noDupErr, specConflict, arbiterIndexes, false)
+
+/* 70b42f2790292cc30aa07563f343f7ba6749af01 */
+#define EvalPlanQualInit(epqstate, parentestate, subplan, auxrowmarks, epqParam) \
+	EvalPlanQualInit(epqstate, parentestate, subplan, auxrowmarks, epqParam, NIL)
 
 #endif

--- a/compat95/pglogical_compat.h
+++ b/compat95/pglogical_compat.h
@@ -104,4 +104,6 @@ replorigin_drop_by_name(char *name, bool missing_ok, bool nowait)
 		replorigin_drop(originid, nowait);
 }
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/compat96/pglogical_compat.h
+++ b/compat96/pglogical_compat.h
@@ -88,4 +88,6 @@ replorigin_drop_by_name(char *name, bool missing_ok, bool nowait)
 		replorigin_drop(originid, nowait);
 }
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif

--- a/pglogical.c
+++ b/pglogical.c
@@ -99,7 +99,7 @@ shmem_request_hook_type prev_shmem_request_hook = NULL;
 #endif
 
 void _PG_init(void);
-void pglogical_supervisor_main(Datum main_arg);
+void PGDLLEXPORT pglogical_supervisor_main(Datum main_arg);
 char *pglogical_extra_connection_options;
 
 static PGconn * pglogical_connect_base(const char *connstr,

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -75,7 +75,7 @@
 #include "pglogical.h"
 
 
-void pglogical_apply_main(Datum main_arg);
+void PGDLLEXPORT pglogical_apply_main(Datum main_arg);
 
 static bool			in_remote_transaction = false;
 static XLogRecPtr	remote_origin_lsn = InvalidXLogRecPtr;
@@ -1971,7 +1971,7 @@ pglogical_apply_main(Datum main_arg)
 	originid = replorigin_by_name(MySubscription->slot_name, false);
 	elog(DEBUG2, "setting up replication origin %s (oid %u)",
 		MySubscription->slot_name, originid);
-	replorigin_session_setup(originid);
+	PGLreplorigin_session_setup(originid);
 	replorigin_session_origin = originid;
 	origin_startpos = replorigin_session_get_progress(false);
 

--- a/pglogical_apply_heap.c
+++ b/pglogical_apply_heap.c
@@ -406,7 +406,9 @@ pglogical_apply_heap_insert(PGLogicalRelation *rel, PGLogicalTupleData *newtup)
 
 		if (apply)
 		{
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 160000
+			TU_UpdateIndexes update_indexes;
+#elif PG_VERSION_NUM >= 120000
 			bool update_indexes;
 #endif
 
@@ -633,7 +635,9 @@ pglogical_apply_heap_update(PGLogicalRelation *rel, PGLogicalTupleData *oldtup,
 
 		if (apply)
 		{
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 160000
+			TU_UpdateIndexes update_indexes;
+#elif PG_VERSION_NUM >= 120000
 			bool update_indexes;
 #endif
 

--- a/pglogical_conflict.c
+++ b/pglogical_conflict.c
@@ -341,10 +341,10 @@ pglogical_tuple_find_conflict(ResultRelInfo *relinfo, PGLogicalTupleData *tuple,
 	replidxoid = RelationGetReplicaIndex(relinfo->ri_RelationDesc);
 	if (OidIsValid(replidxoid))
 	{
-		ScanKeyData	index_key[INDEX_MAX_KEYS];
+		ScanKeyData	index_key1[INDEX_MAX_KEYS];
 		Relation	idxrel = index_open(replidxoid, RowExclusiveLock);
-		build_index_scan_key(index_key, relinfo->ri_RelationDesc, idxrel, tuple);
-		found = find_index_tuple(index_key, relinfo->ri_RelationDesc, idxrel,
+		build_index_scan_key(index_key1, relinfo->ri_RelationDesc, idxrel, tuple);
+		found = find_index_tuple(index_key1, relinfo->ri_RelationDesc, idxrel,
 							 LockTupleExclusive, outslot);
 		index_close(idxrel, NoLock);
 		if (found)

--- a/pglogical_executor.c
+++ b/pglogical_executor.c
@@ -39,6 +39,9 @@
 #endif
 
 #include "parser/parse_coerce.h"
+#if PG_VERSION_NUM >= 160000
+#include "parser/parse_relation.h"
+#endif
 
 #include "tcop/utility.h"
 
@@ -70,6 +73,9 @@ create_estate_for_relation(Relation rel, bool forwrite)
 {
 	EState	   *estate;
 	RangeTblEntry *rte;
+#if PG_VERSION_NUM >= 160000
+	List	   *perminfos = NIL;
+#endif
 
 
 	/* Dummy range table entry needed by executor. */
@@ -80,7 +86,10 @@ create_estate_for_relation(Relation rel, bool forwrite)
 
 	/* Initialize executor state. */
 	estate = CreateExecutorState();
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 160000
+	addRTEPermissionInfo(&perminfos, rte);
+	ExecInitRangeTable(estate, list_make1(rte), perminfos);
+#elif PG_VERSION_NUM >= 120000
 	ExecInitRangeTable(estate, list_make1(rte));
 #elif PG_VERSION_NUM >= 110000 && SECONDQ_VERSION_NUM >= 103
 	/* 2ndQPostgres 11 r1.3 changes executor API */

--- a/pglogical_manager.c
+++ b/pglogical_manager.c
@@ -36,7 +36,7 @@
 #define MAX_SLEEP 180000L
 #define MIN_SLEEP 5000L
 
-void pglogical_manager_main(Datum main_arg);
+void PGDLLEXPORT pglogical_manager_main(Datum main_arg);
 
 /*
  * Manage the apply workers - start new ones, kill old ones.

--- a/pglogical_output_config.c
+++ b/pglogical_output_config.c
@@ -228,15 +228,15 @@ process_parameters_v1(List *options, PGLogicalOutputData *data)
 			case PARAM_PGLOGICAL_FORWARD_ORIGINS:
 				{
 					List		   *forward_origin_names;
-					ListCell	   *lc;
+					ListCell	   *lc1;
 					val = get_param_value(elem, false, OUTPUT_PARAM_TYPE_STRING);
 
 					if (!SplitIdentifierString(DatumGetCString(val), ',', &forward_origin_names))
 						elog(ERROR, "Could not parse forward origin name list %s", DatumGetCString(val));
 
-					foreach (lc, forward_origin_names)
+					foreach (lc1, forward_origin_names)
 					{
-						char	   *origin_name = (char *) lfirst(lc);
+						char	   *origin_name = (char *) lfirst(lc1);
 
 						if (strcmp(origin_name, REPLICATION_ORIGIN_ALL) != 0)
 							elog(ERROR, "Only \"%s\" is allowed in forward origin name list at the moment, found \"%s\"",

--- a/pglogical_proto_json.c
+++ b/pglogical_proto_json.c
@@ -25,6 +25,7 @@
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "replication/reorderbuffer.h"
+#include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/json.h"
 #include "utils/lsyscache.h"

--- a/pglogical_relcache.c
+++ b/pglogical_relcache.c
@@ -81,7 +81,6 @@ pglogical_relation_open(uint32 remoteid, LOCKMODE lockmode)
 	if (!OidIsValid(entry->reloid))
 	{
 		RangeVar   *rv = makeNode(RangeVar);
-		int			i;
 		TupleDesc	desc;
 
 		rv->schemaname = (char *) entry->nspname;
@@ -89,7 +88,7 @@ pglogical_relation_open(uint32 remoteid, LOCKMODE lockmode)
 		entry->rel = table_openrv(rv, lockmode);
 
 		desc = RelationGetDescr(entry->rel);
-		for (i = 0; i < entry->natts; i++)
+		for (int i = 0; i < entry->natts; i++)
 			entry->attmap[i] = tupdesc_get_att_by_name(desc, entry->attnames[i]);
 
 		entry->reloid = RelationGetRelid(entry->rel);

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -572,7 +572,7 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 	{
 		StringInfoData	relname;
 		StringInfoData	repsetarr;
-		ListCell   *lc;
+		ListCell   *lc1;
 
 		initStringInfo(&relname);
 		appendStringInfo(&relname, "%s.%s",
@@ -583,9 +583,9 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 
 		initStringInfo(&repsetarr);
 		first = true;
-		foreach (lc, replication_sets)
+		foreach (lc1, replication_sets)
 		{
-			char	   *repset_name = lfirst(lc);
+			char	   *repset_name = lfirst(lc1);
 
 			if (first)
 				first = false;

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -86,7 +86,7 @@
 #define Anum_sync_status		5
 #define Anum_sync_statuslsn		6
 
-void pglogical_sync_main(Datum main_arg);
+void PGDLLEXPORT pglogical_sync_main(Datum main_arg);
 
 static PGLogicalSyncWorker	   *MySyncWorker = NULL;
 
@@ -1262,7 +1262,7 @@ pglogical_sync_main(Datum main_arg)
 	originid = replorigin_by_name(MySubscription->slot_name, false);
 	elog(DEBUG2, "setting origin %s (oid %u) for subscription sync",
 		MySubscription->slot_name, originid);
-	replorigin_session_setup(originid);
+	PGLreplorigin_session_setup(originid);
 	replorigin_session_origin = originid;
 	Assert(status_lsn == replorigin_session_get_progress(false));
 


### PR DESCRIPTION
It includes support for Postgres 16. Since this new release includes `-Wshadow=compatible-local`, there is an additional commit to rename a variable that shadows another variable. It also includes `-fvisibility=hidden` that requires adding PGDLLEXPORT to the worker main functions.

It passes the tests from version 9.5 to 16 beta3 (The `add_table` test always fails. The `row_filter` test has a different error message that causes a failure for 9.5 and 9.6. We could add an alternative test but it is a deprecated version so ...).