### PR TITLE
Fix build on v9.4.

### DIFF
--- a/compat94/pglogical_compat.h
+++ b/compat94/pglogical_compat.h
@@ -188,4 +188,6 @@ extern void CatalogTupleDelete(Relation heapRel, ItemPointer tid);
 #define pg_plan_queries(querytrees, query_string, cursorOptions, boundParams) \
 	pg_plan_queries(querytrees, cursorOptions, boundParams)
 
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node)
+
 #endif


### PR DESCRIPTION
Commit 418099df971835560eb5ac6076955fcc65eb4599 added this macro to every other pglogical_compat.h.

`make installcheck` passes.