### PR TITLE
Make backend query execution interruptible.

### DIFF
--- a/compat10/pglogical_compat.h
+++ b/compat10/pglogical_compat.h
@@ -8,6 +8,8 @@
 #include "replication/origin.h"
 #include "utils/varlena.h"
 
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
+
 #define PGLCreateTrigger CreateTrigger
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \

--- a/compat11/pglogical_compat.h
+++ b/compat11/pglogical_compat.h
@@ -1,8 +1,11 @@
 #ifndef PG_LOGICAL_COMPAT_H
 #define PG_LOGICAL_COMPAT_H
 
+#include "pgstat.h"
 #include "replication/origin.h"
 #include "utils/varlena.h"
+
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
 	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)

--- a/compat12/pglogical_compat.h
+++ b/compat12/pglogical_compat.h
@@ -1,12 +1,15 @@
 #ifndef PG_LOGICAL_COMPAT_H
 #define PG_LOGICAL_COMPAT_H
 
+#include "pgstat.h"
 #include "access/amapi.h"
 #include "access/heapam.h"
 #include "access/table.h"
 #include "access/tableam.h"
 #include "replication/origin.h"
 #include "utils/varlena.h"
+
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
 	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)

--- a/compat13/pglogical_compat.h
+++ b/compat13/pglogical_compat.h
@@ -1,12 +1,15 @@
 #ifndef PG_LOGICAL_COMPAT_H
 #define PG_LOGICAL_COMPAT_H
 
+#include "pgstat.h"
 #include "access/amapi.h"
 #include "access/heapam.h"
 #include "access/table.h"
 #include "access/tableam.h"
 #include "replication/origin.h"
 #include "utils/varlena.h"
+
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
 	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)

--- a/compat14/pglogical_compat.h
+++ b/compat14/pglogical_compat.h
@@ -6,6 +6,9 @@
 #include "access/table.h"
 #include "access/tableam.h"
 #include "utils/varlena.h"
+#include "utils/wait_event.h"
+
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
 	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)

--- a/compat15/pglogical_compat.h
+++ b/compat15/pglogical_compat.h
@@ -6,6 +6,9 @@
 #include "access/table.h"
 #include "access/tableam.h"
 #include "utils/varlena.h"
+#include "utils/wait_event.h"
+
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
 	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)

--- a/compat16/pglogical_compat.h
+++ b/compat16/pglogical_compat.h
@@ -6,6 +6,10 @@
 #include "access/table.h"
 #include "access/tableam.h"
 #include "utils/varlena.h"
+#include "utils/wait_event.h"
+
+#include "libpq/libpq-be-fe-helpers.h"
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
 
 #define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
 	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)

--- a/compat94/pglogical_compat.h
+++ b/compat94/pglogical_compat.h
@@ -12,6 +12,9 @@
 #include "storage/lwlock.h"
 #include "utils/array.h"
 
+#define PG_WAIT_EXTENSION 0
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
+
 /* 9.4 lacks PG_*_MAX */
 #ifndef PG_UINT32_MAX
 #define PG_UINT32_MAX	(0xFFFFFFFF)

--- a/compat94/pglogical_libpq-be-fe-helpers.h
+++ b/compat94/pglogical_libpq-be-fe-helpers.h
@@ -1,0 +1,438 @@
+/*-------------------------------------------------------------------------
+ *
+ * libpq-be-fe-helpers.h
+ *	  Helper functions for using libpq in extensions
+ *
+ * Code built directly into the backend is not allowed to link to libpq
+ * directly. Extension code is allowed to use libpq however. However, libpq
+ * used in extensions has to be careful not to block inside libpq, otherwise
+ * interrupts will not be processed, leading to issues like unresolvable
+ * deadlocks. Backend code also needs to take care to acquire/release an
+ * external fd for the connection, otherwise fd.c's accounting of fd's is
+ * broken.
+ *
+ * This file provides helper functions to make it easier to comply with these
+ * rules. It is a header only library as it needs to be linked into each
+ * extension using libpq, and it seems too small to be worth adding a
+ * dedicated static library for.
+ *
+ * TODO: For historical reasons the connections established here are not put
+ * into non-blocking mode. That can lead to blocking even when only the async
+ * libpq functions are used. This should be fixed.
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/libpq/libpq-be-fe-helpers.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef LIBPQ_BE_FE_HELPERS_H
+#define LIBPQ_BE_FE_HELPERS_H
+
+/*
+ * Despite the name, BUILDING_DLL is set only when building code directly part
+ * of the backend. Which also is where libpq isn't allowed to be
+ * used. Obviously this doesn't protect against libpq-fe.h getting included
+ * otherwise, but perhaps still protects against a few mistakes...
+ */
+#ifdef BUILDING_DLL
+#error "libpq may not be used code directly built into the backend"
+#endif
+
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "storage/fd.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/proc.h"
+
+
+#if PG_VERSION_NUM < 100000
+#define WaitLatchOrSocket(latch, wakeEvents, sock, timeout, wait_event_info) \
+	WaitLatchOrSocket(latch, wakeEvents, sock, timeout)
+#else
+#define WaitLatchOrSocket(latch, wakeEvents, sock, timeout, wait_event_info) \
+	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, wait_event_info)
+#endif
+
+#if PG_VERSION_NUM < 130000
+#define AcquireExternalFD() (true)
+#define ReleaseExternalFD() do {} while (0)
+#endif
+
+#if PG_VERSION_NUM < 90500
+#define MyLatch (&MyProc->procLatch)
+#endif
+
+
+static inline void libpqsrv_connect_prepare(void);
+static inline void libpqsrv_connect_internal(PGconn *conn, uint32 wait_event_info);
+
+
+/*
+ * PQconnectdb() wrapper that reserves a file descriptor and processes
+ * interrupts during connection establishment.
+ *
+ * Throws an error if AcquireExternalFD() fails, but does not throw if
+ * connection establishment itself fails. Callers need to use PQstatus() to
+ * check if connection establishment succeeded.
+ */
+static inline PGconn *
+libpqsrv_connect(const char *conninfo, uint32 wait_event_info)
+{
+	PGconn	   *conn = NULL;
+
+	libpqsrv_connect_prepare();
+
+	conn = PQconnectStart(conninfo);
+
+	libpqsrv_connect_internal(conn, wait_event_info);
+
+	return conn;
+}
+
+/*
+ * Like libpqsrv_connect(), except that this is a wrapper for
+ * PQconnectdbParams().
+  */
+static inline PGconn *
+libpqsrv_connect_params(const char *const *keywords,
+						const char *const *values,
+						int expand_dbname,
+						uint32 wait_event_info)
+{
+	PGconn	   *conn = NULL;
+
+	libpqsrv_connect_prepare();
+
+	conn = PQconnectStartParams(keywords, values, expand_dbname);
+
+	libpqsrv_connect_internal(conn, wait_event_info);
+
+	return conn;
+}
+
+/*
+ * PQfinish() wrapper that additionally releases the reserved file descriptor.
+ *
+ * It is allowed to call this with a NULL pgconn iff NULL was returned by
+ * libpqsrv_connect*.
+ */
+static inline void
+libpqsrv_disconnect(PGconn *conn)
+{
+	/*
+	 * If no connection was established, we haven't reserved an FD for it (or
+	 * already released it). This rule makes it easier to write PG_CATCH()
+	 * handlers for this facility's users.
+	 *
+	 * See also libpqsrv_connect_internal().
+	 */
+	if (conn == NULL)
+		return;
+
+	ReleaseExternalFD();
+	PQfinish(conn);
+}
+
+
+/* internal helper functions follow */
+
+
+/*
+ * Helper function for all connection establishment functions.
+ */
+static inline void
+libpqsrv_connect_prepare(void)
+{
+	/*
+	 * We must obey fd.c's limit on non-virtual file descriptors.  Assume that
+	 * a PGconn represents one long-lived FD.  (Doing this here also ensures
+	 * that VFDs are closed if needed to make room.)
+	 */
+	if (!AcquireExternalFD())
+	{
+#ifndef WIN32					/* can't write #if within ereport() macro */
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("could not establish connection"),
+				 errdetail("There are too many open files on the local server."),
+				 errhint("Raise the server's max_files_per_process and/or \"ulimit -n\" limits.")));
+#else
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("could not establish connection"),
+				 errdetail("There are too many open files on the local server."),
+				 errhint("Raise the server's max_files_per_process setting.")));
+#endif
+	}
+}
+
+/*
+ * Helper function for all connection establishment functions.
+ */
+static inline void
+libpqsrv_connect_internal(PGconn *conn, uint32 wait_event_info)
+{
+	/*
+	 * With conn == NULL libpqsrv_disconnect() wouldn't release the FD. So do
+	 * that here.
+	 */
+	if (conn == NULL)
+	{
+		ReleaseExternalFD();
+		return;
+	}
+
+	/*
+	 * Can't wait without a socket. Note that we don't want to close the libpq
+	 * connection yet, so callers can emit a useful error.
+	 */
+	if (PQstatus(conn) == CONNECTION_BAD)
+		return;
+
+	/*
+	 * WaitLatchOrSocket() can conceivably fail, handle that case here instead
+	 * of requiring all callers to do so.
+	 */
+	PG_TRY();
+	{
+		PostgresPollingStatusType status;
+
+		/*
+		 * Poll connection until we have OK or FAILED status.
+		 *
+		 * Per spec for PQconnectPoll, first wait till socket is write-ready.
+		 */
+		status = PGRES_POLLING_WRITING;
+		while (status != PGRES_POLLING_OK && status != PGRES_POLLING_FAILED)
+		{
+			int			io_flag;
+			int			rc;
+
+			if (status == PGRES_POLLING_READING)
+				io_flag = WL_SOCKET_READABLE;
+#ifdef WIN32
+
+			/*
+			 * Windows needs a different test while waiting for
+			 * connection-made
+			 */
+			else if (PQstatus(conn) == CONNECTION_STARTED)
+				io_flag = WL_SOCKET_CONNECTED;
+#endif
+			else
+				io_flag = WL_SOCKET_WRITEABLE;
+
+			rc = WaitLatchOrSocket(MyLatch,
+								   WL_POSTMASTER_DEATH | WL_LATCH_SET | io_flag,
+								   PQsocket(conn),
+								   0,
+								   wait_event_info);
+
+			/* emergency bailout if postmaster has died */
+			if (rc & WL_POSTMASTER_DEATH)
+				proc_exit(1);
+
+			/* Interrupted? */
+			if (rc & WL_LATCH_SET)
+			{
+				ResetLatch(MyLatch);
+				CHECK_FOR_INTERRUPTS();
+			}
+
+			/* If socket is ready, advance the libpq state machine */
+			if (rc & io_flag)
+				status = PQconnectPoll(conn);
+		}
+	}
+	PG_CATCH();
+	{
+		/*
+		 * If an error is thrown here, the callers won't call
+		 * libpqsrv_disconnect() with a conn, so release resources
+		 * immediately.
+		 */
+		ReleaseExternalFD();
+		PQfinish(conn);
+
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+}
+
+#undef WaitLatchOrSocket
+#undef AcquireExternalFD
+#undef ReleaseExternalFD
+#undef MyLatch
+
+#endif							/* LIBPQ_BE_FE_HELPERS_H */
+
+/*
+ * Preceding half of file is v16+ header content, and following half is v17+
+ * header content.  By using separate include guards, v16 can include both
+ * this header and PostgreSQL's libpq/libpq-be-fe-helpers.h.
+ */
+
+#ifndef PGLOGICAL_LIBPQ_BE_FE_HELPERS_H
+#define PGLOGICAL_LIBPQ_BE_FE_HELPERS_H
+
+#include "libpq-fe.h"
+#include "miscadmin.h"
+#include "storage/fd.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/proc.h"
+
+
+#if PG_VERSION_NUM >= 100000
+#define WaitLatchOrSocket(latch, wakeEvents, sock, timeout, wait_event_info) \
+	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, wait_event_info)
+#else
+#define WaitLatchOrSocket(latch, wakeEvents, sock, timeout, wait_event_info) \
+	WaitLatchOrSocket(latch, wakeEvents, sock, timeout)
+#endif
+
+#if PG_VERSION_NUM < 90500
+#define MyLatch (&MyProc->procLatch)
+#endif
+
+
+static inline PGresult *libpqsrv_get_result_last(PGconn *conn, uint32 wait_event_info);
+static inline PGresult *libpqsrv_get_result(PGconn *conn, uint32 wait_event_info);
+
+/*
+ * PQexec() wrapper that processes interrupts.
+ *
+ * Unless PQsetnonblocking(conn, 1) is in effect, this can't process
+ * interrupts while pushing the query text to the server.  Consider that
+ * setting if query strings can be long relative to TCP buffer size.
+ *
+ * This has the preconditions of PQsendQuery(), not those of PQexec().  Most
+ * notably, PQexec() would silently discard any prior query results.
+ */
+static inline PGresult *
+libpqsrv_exec(PGconn *conn, const char *query, uint32 wait_event_info)
+{
+	if (!PQsendQuery(conn, query))
+		return NULL;
+	return libpqsrv_get_result_last(conn, wait_event_info);
+}
+
+/*
+ * PQexecParams() wrapper that processes interrupts.
+ *
+ * See notes at libpqsrv_exec().
+ */
+static inline PGresult *
+libpqsrv_exec_params(PGconn *conn,
+					 const char *command,
+					 int nParams,
+					 const Oid *paramTypes,
+					 const char *const *paramValues,
+					 const int *paramLengths,
+					 const int *paramFormats,
+					 int resultFormat,
+					 uint32 wait_event_info)
+{
+	if (!PQsendQueryParams(conn, command, nParams, paramTypes, paramValues,
+						   paramLengths, paramFormats, resultFormat))
+		return NULL;
+	return libpqsrv_get_result_last(conn, wait_event_info);
+}
+
+/*
+ * Like PQexec(), loop over PQgetResult() until it returns NULL or another
+ * terminal state.  Return the last non-NULL result or the terminal state.
+ */
+static inline PGresult *
+libpqsrv_get_result_last(PGconn *conn, uint32 wait_event_info)
+{
+	PGresult   *volatile lastResult = NULL;
+
+	/* In what follows, do not leak any PGresults on an error. */
+	PG_TRY();
+	{
+		for (;;)
+		{
+			/* Wait for, and collect, the next PGresult. */
+			PGresult   *result;
+
+			result = libpqsrv_get_result(conn, wait_event_info);
+			if (result == NULL)
+				break;			/* query is complete, or failure */
+
+			/*
+			 * Emulate PQexec()'s behavior of returning the last result when
+			 * there are many.
+			 */
+			PQclear(lastResult);
+			lastResult = result;
+
+			if (PQresultStatus(lastResult) == PGRES_COPY_IN ||
+				PQresultStatus(lastResult) == PGRES_COPY_OUT ||
+				PQresultStatus(lastResult) == PGRES_COPY_BOTH ||
+				PQstatus(conn) == CONNECTION_BAD)
+				break;
+		}
+	}
+	PG_CATCH();
+	{
+		PQclear(lastResult);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	return lastResult;
+}
+
+/*
+ * Perform the equivalent of PQgetResult(), but watch for interrupts.
+ */
+static inline PGresult *
+libpqsrv_get_result(PGconn *conn, uint32 wait_event_info)
+{
+	/*
+	 * Collect data until PQgetResult is ready to get the result without
+	 * blocking.
+	 */
+	while (PQisBusy(conn))
+	{
+		int			rc;
+
+		rc = WaitLatchOrSocket(MyLatch,
+							   WL_POSTMASTER_DEATH | WL_LATCH_SET |
+							   WL_SOCKET_READABLE,
+							   PQsocket(conn),
+							   0,
+							   wait_event_info);
+
+		/* emergency bailout if postmaster has died */
+		if (rc & WL_POSTMASTER_DEATH)
+			proc_exit(1);
+
+		/* Interrupted? */
+		if (rc & WL_LATCH_SET)
+		{
+			ResetLatch(MyLatch);
+			CHECK_FOR_INTERRUPTS();
+		}
+
+		/* Consume whatever data is available from the socket */
+		if (PQconsumeInput(conn) == 0)
+		{
+			/* trouble; expect PQgetResult() to return NULL */
+			break;
+		}
+	}
+
+	/* Now we can collect and return the next PGresult */
+	return PQgetResult(conn);
+}
+
+
+#undef WaitLatchOrSocket
+#undef MyLatch
+
+#endif							/* PGLOGICAL_LIBPQ_BE_FE_HELPERS_H */

--- a/compat95/pglogical_compat.h
+++ b/compat95/pglogical_compat.h
@@ -9,6 +9,9 @@
 #include "replication/origin.h"
 #include "storage/lwlock.h"
 
+#define PG_WAIT_EXTENSION 0
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
+
 extern LWLockPadded *GetNamedLWLockTranche(const char *tranche_name);
 extern void RequestNamedLWLockTranche(const char *tranche_name, int num_lwlocks);
 

--- a/compat96/pglogical_compat.h
+++ b/compat96/pglogical_compat.h
@@ -7,6 +7,9 @@
 #include "executor/executor.h"
 #include "replication/origin.h"
 
+#define PG_WAIT_EXTENSION 0
+#include "compat94/pglogical_libpq-be-fe-helpers.h"
+
 #define PGLCreateTrigger CreateTrigger
 
 #define RawStmt Node

--- a/pglogical.c
+++ b/pglogical.c
@@ -431,7 +431,8 @@ pglogical_identify_system(PGconn *streamConn, uint64* sysid,
 {
 	PGresult	   *res;
 
-	res = PQexec(streamConn, "IDENTIFY_SYSTEM");
+	res = libpqsrv_exec(streamConn, "IDENTIFY_SYSTEM",
+						PG_WAIT_EXTENSION);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
 	{
 		elog(ERROR, "could not send replication command \"%s\": %s",
@@ -578,7 +579,7 @@ pglogical_start_replication(PGconn *streamConn, const char *slot_name,
 
 	appendStringInfoChar(&command, ')');
 
-	res = PQexec(streamConn, command.data);
+	res = libpqsrv_exec(streamConn, command.data, PG_WAIT_EXTENSION);
 	sqlstate = PQresultErrorField(res, PG_DIAG_SQLSTATE);
 	if (PQresultStatus(res) != PGRES_COPY_BOTH)
 		elog(FATAL, "could not send replication command \"%s\": %s\n, sqlstate: %s",

--- a/pglogical.h
+++ b/pglogical.h
@@ -20,8 +20,6 @@
 #include "executor/executor.h"
 #include "miscadmin.h"
 
-#include "libpq-fe.h"
-
 #include "pglogical_fe.h"
 #include "pglogical_node.h"
 

--- a/pglogical_conflict.c
+++ b/pglogical_conflict.c
@@ -47,6 +47,7 @@
 
 #include "pglogical_conflict.h"
 #include "pglogical_proto_native.h"
+#include "pglogical.h"
 
 int		pglogical_conflict_resolver = PGLOGICAL_RESOLVE_APPLY_REMOTE;
 int		pglogical_conflict_log_level = LOG;

--- a/pglogical_output_plugin.h
+++ b/pglogical_output_plugin.h
@@ -16,9 +16,6 @@
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
 
-/* summon cross-PG-version compatibility voodoo */
-#include "pglogical_compat.h"
-
 /* typedef appears in pglogical_output_plugin.h */
 typedef struct PGLogicalOutputData
 {

--- a/pglogical_output_proto.c
+++ b/pglogical_output_proto.c
@@ -17,6 +17,7 @@
 #include "pglogical_output_proto.h"
 #include "pglogical_proto_native.h"
 #include "pglogical_proto_json.h"
+#include "pglogical.h"
 
 PGLogicalProtoAPI *
 pglogical_init_api(PGLogicalProtoType typ)

--- a/pglogical_proto_json.c
+++ b/pglogical_proto_json.c
@@ -37,6 +37,7 @@
 
 #include "pglogical_output_plugin.h"
 #include "pglogical_proto_json.h"
+#include "pglogical.h"
 
 #ifdef HAVE_REPLICATION_ORIGINS
 #include "replication/origin.h"

--- a/pglogical_proto_native.c
+++ b/pglogical_proto_native.c
@@ -29,6 +29,7 @@
 #include "pglogical_output_plugin.h"
 #include "pglogical_output_proto.h"
 #include "pglogical_proto_native.h"
+#include "pglogical.h"
 
 #define IS_REPLICA_IDENTITY 1
 


### PR DESCRIPTION
This prevents v15+ DROP DATABASE hanging when a pglogical process waits inside
one of these calls.  (See https://github.com/2ndQuadrant/pglogical/issues/418
for fixes of that symptom under different conditions.)  In all versions, it
brings responsiveness of these calls to query cancel, backend termination, and
fast shutdown.

Future work should include adopting libpqsrv_connect_params().  I didn't bundle
that in this pull request, because that function doesn't support all the
connection parameters that PQconnectdbParams() supports.  Specifically, since
libpqsrv_connect_params() wraps PQconnectStartParams(), it has the limitations
discussed in
https://postgr.es/m/flat/CA%2Bmi_8YyGKA9dWELu63e%3DKL2oN-%2BFe4uca4EtFfb6uQD4Up8pw%40mail.gmail.com.
Future work should also bring interruptibility to calls of
PQgetCopyData(async=false), PQputCopyData(), and PQputCopyEnd().

No new test failures in:
- "make check" @ v9.5+
- "make installcheck" @ v9.4, using https://github.com/2ndQuadrant/pglogical/pull/450 for v9.4 support
- "make prove_check" @ v9.6 - v14

When v17 support appears, compat17/pglogical_compat.h can just #include
"libpq/libpq-be-fe-helpers.h" rather than use the local copy.