### PR TITLE
Prevent RepSetTableHash entry fields from being freed during invalidation callback

### DIFF
--- a/expected/row_filter_sampling.out
+++ b/expected/row_filter_sampling.out
@@ -93,3 +93,52 @@ NOTICE:  drop cascades to table public.test_tablesample membership in replicatio
  t
 (1 row)
 
+CREATE TABLE sample_rowfilter_table(id int primary key, name text);
+\COPY sample_rowfilter_table(id, name) FROM STDIN WITH CSV
+SELECT pglogical.create_replication_set('sample_publisher_set', true, true, true, true);
+ create_replication_set 
+------------------------
+             1195464429
+(1 row)
+
+SELECT pglogical.replication_set_add_table(set_name := 'sample_publisher_set', relation := 'public.sample_rowfilter_table', row_filter := $$ id >= 1  and id <= 3 $$);
+ replication_set_add_table 
+---------------------------
+ t
+(1 row)
+
+SELECT * FROM pglogical.table_data_filtered(NULL::"public"."sample_rowfilter_table", '"public"."sample_rowfilter_table"'::regclass, ARRAY['sample_publisher_set']);
+ id | name 
+----+------
+  1 | John
+  2 | Jane
+  3 | Bob
+(3 rows)
+
+SELECT pglogical.replication_set_remove_table('sample_publisher_set', '"public"."sample_rowfilter_table"'::regclass);
+ replication_set_remove_table 
+------------------------------
+ t
+(1 row)
+
+SELECT pglogical.replication_set_add_table(set_name := 'sample_publisher_set', relation := 'public.sample_rowfilter_table', row_filter := $$ id >= 4  and id <= 6 $$);
+ replication_set_add_table 
+---------------------------
+ t
+(1 row)
+
+SELECT * FROM pglogical.table_data_filtered(NULL::"public"."sample_rowfilter_table", '"public"."sample_rowfilter_table"'::regclass, ARRAY['sample_publisher_set']);
+ id |  name   
+----+---------
+  4 | Alice
+  5 | Charlie
+  6 | Eve
+(3 rows)
+
+SELECT pglogical.drop_replication_set('sample_publisher_set');
+ drop_replication_set 
+----------------------
+ t
+(1 row)
+
+DROP TABLE sample_rowfilter_table;

--- a/expected/row_filter_sampling.out
+++ b/expected/row_filter_sampling.out
@@ -115,6 +115,11 @@ SELECT * FROM pglogical.table_data_filtered(NULL::"public"."sample_rowfilter_tab
   3 | Bob
 (3 rows)
 
+-- Try to trigger cache invalidation for the sample_rowfilter_table relation
+-- while program execution is inside create_estate_for_relation(), called from
+-- pglogical_table_data_filtered().  To reach that reliably, one can run the
+-- test suite under debug_discard_caches=1.  This helps verify row_filter is
+-- applied correctly even during cache invalidation.
 SELECT pglogical.replication_set_remove_table('sample_publisher_set', '"public"."sample_rowfilter_table"'::regclass);
  replication_set_remove_table 
 ------------------------------

--- a/pglogical_repset.c
+++ b/pglogical_repset.c
@@ -398,14 +398,14 @@ get_table_replication_info(Oid nodeid, Relation table,
 	{
 		if (entry->att_list)
 			pfree(entry->att_list);
-		
+
 		if (list_length(entry->row_filter))
 			list_free_deep(entry->row_filter);
 	}
 
 	/* Reset all fields in the entry structure except for reloid */
-    MemSet(((char *) entry) + sizeof(entry->reloid), 0, sizeof(PGLogicalTableRepInfo) - sizeof(Oid));
-	
+	MemSet(((char *) entry) + sizeof(entry->reloid), 0, sizeof(PGLogicalTableRepInfo) - sizeof(Oid));
+
 	/* Fill the entry */
 	/*
 	 * Check for match between table's replication sets and the subscription

--- a/pglogical_repset.c
+++ b/pglogical_repset.c
@@ -210,24 +210,12 @@ repset_relcache_invalidate_callback(Datum arg, Oid reloid)
 		while ((entry = hash_seq_search(&status)) != NULL)
 		{
 			entry->isvalid = false;
-			if (entry->att_list)
-				pfree(entry->att_list);
-			entry->att_list = NULL;
-			if (list_length(entry->row_filter))
-				list_free_deep(entry->row_filter);
-			entry->row_filter = NIL;
 		}
 	}
 	else if ((entry = hash_search(RepSetTableHash, &reloid,
 								  HASH_FIND, NULL)) != NULL)
 	{
 		entry->isvalid = false;
-		if (entry->att_list)
-			pfree(entry->att_list);
-		entry->att_list = NULL;
-		if (list_length(entry->row_filter))
-			list_free_deep(entry->row_filter);
-		entry->row_filter = NIL;
 	}
 }
 
@@ -405,14 +393,20 @@ get_table_replication_info(Oid nodeid, Relation table,
 	if (found && entry->isvalid)
 		return entry;
 
-	/* Fill the entry */
-	entry->reloid = reloid;
-	entry->replicate_insert = false;
-	entry->replicate_update = false;
-	entry->replicate_delete = false;
-	entry->att_list = NULL;
-	entry->row_filter = NIL;
+	/* If an entry was found but entry is Invalid, free its att_list and row_filter fields if they are allocated */
+	if (found)
+	{
+		if (entry->att_list)
+			pfree(entry->att_list);
+		
+		if (list_length(entry->row_filter))
+			list_free_deep(entry->row_filter);
+	}
 
+	/* Reset all fields in the entry structure except for reloid */
+    MemSet(((char *) entry) + sizeof(entry->reloid), 0, sizeof(PGLogicalTableRepInfo) - sizeof(Oid));
+	
+	/* Fill the entry */
 	/*
 	 * Check for match between table's replication sets and the subscription
 	 * list of replication sets that was given as parameter.

--- a/sql/row_filter_sampling.sql
+++ b/sql/row_filter_sampling.sql
@@ -61,9 +61,11 @@ SELECT pglogical.create_replication_set('sample_publisher_set', true, true, true
 SELECT pglogical.replication_set_add_table(set_name := 'sample_publisher_set', relation := 'public.sample_rowfilter_table', row_filter := $$ id >= 1  and id <= 3 $$);
 SELECT * FROM pglogical.table_data_filtered(NULL::"public"."sample_rowfilter_table", '"public"."sample_rowfilter_table"'::regclass, ARRAY['sample_publisher_set']);
 
--- NOTE: For developers: try to trigger cache invalidation for the sample_rowfilter_table relation
--- while program execution is inside create_estate_for_relation() called from pglogical_table_data_filtered().
--- This helps verify whether row_filter is applied correctly even during cache invalidation.
+-- Try to trigger cache invalidation for the sample_rowfilter_table relation
+-- while program execution is inside create_estate_for_relation(), called from
+-- pglogical_table_data_filtered().  To reach that reliably, one can run the
+-- test suite under debug_discard_caches=1.  This helps verify row_filter is
+-- applied correctly even during cache invalidation.
 
 SELECT pglogical.replication_set_remove_table('sample_publisher_set', '"public"."sample_rowfilter_table"'::regclass);
 SELECT pglogical.replication_set_add_table(set_name := 'sample_publisher_set', relation := 'public.sample_rowfilter_table', row_filter := $$ id >= 4  and id <= 6 $$);

--- a/sql/row_filter_sampling.sql
+++ b/sql/row_filter_sampling.sql
@@ -44,3 +44,31 @@ DROP FUNCTION funcn_get_bernoulli_sample_count(integer, integer);
 SELECT pglogical.replicate_ddl_command($$
 	DROP TABLE public.test_tablesample CASCADE;
 $$);
+
+CREATE TABLE sample_rowfilter_table(id int primary key, name text);
+
+\COPY sample_rowfilter_table(id, name) FROM STDIN WITH CSV
+1,John
+2,Jane
+3,Bob
+4,Alice
+5,Charlie
+6,Eve
+\.
+
+SELECT pglogical.create_replication_set('sample_publisher_set', true, true, true, true);
+
+SELECT pglogical.replication_set_add_table(set_name := 'sample_publisher_set', relation := 'public.sample_rowfilter_table', row_filter := $$ id >= 1  and id <= 3 $$);
+SELECT * FROM pglogical.table_data_filtered(NULL::"public"."sample_rowfilter_table", '"public"."sample_rowfilter_table"'::regclass, ARRAY['sample_publisher_set']);
+
+-- NOTE: For developers: try to trigger cache invalidation for the sample_rowfilter_table relation
+-- while program execution is inside create_estate_for_relation() called from pglogical_table_data_filtered().
+-- This helps verify whether row_filter is applied correctly even during cache invalidation.
+
+SELECT pglogical.replication_set_remove_table('sample_publisher_set', '"public"."sample_rowfilter_table"'::regclass);
+SELECT pglogical.replication_set_add_table(set_name := 'sample_publisher_set', relation := 'public.sample_rowfilter_table', row_filter := $$ id >= 4  and id <= 6 $$);
+
+SELECT * FROM pglogical.table_data_filtered(NULL::"public"."sample_rowfilter_table", '"public"."sample_rowfilter_table"'::regclass, ARRAY['sample_publisher_set']);
+
+SELECT pglogical.drop_replication_set('sample_publisher_set');
+DROP TABLE sample_rowfilter_table;


### PR DESCRIPTION
The `repset_relcache_invalidate_callback()` was incorrectly freeing `entry->att_list` and `entry->row_filter` directly during cache invalidation. This is unsafe behavior, as these fields may still be needed by other functions that use the entry even after cache invalidation.

Modifing the `repset_relcache_invalidate_callback()` to only set entry as invalid`(entry->isvalid = false)` and moving the cleanup of fields to `get_table_replication_info()` where reinitializes the entry safely.

See [#496](https://github.com/2ndQuadrant/pglogical/issues/496) issue for more details.