### PR TITLE
Free PQescapeIdentifier/PQescapeIdentifier after used to avoid memory leak

### DIFF
--- a/pglogical_create_subscriber.c
+++ b/pglogical_create_subscriber.c
@@ -801,17 +801,29 @@ initialize_replication_slot(PGconn *conn, char *dbname,
 {
 	PQExpBufferData		query;
 	char			   *slot_name;
+	char			   *escaped_dbname = NULL;
+	char			   *escaped_provider_node_name = NULL;
+	char			   *escaped_subscription_name = NULL;
+	char			   *escaped_slot_name = NULL;
 	PGresult		   *res;
 
 	/* Generate the slot name. */
 	initPQExpBuffer(&query);
+
+	escaped_dbname = PQescapeLiteral(conn, dbname, strlen(dbname));
+	escaped_provider_node_name = PQescapeLiteral(conn, provider_node_name, strlen(provider_node_name));
+	escaped_subscription_name = PQescapeLiteral(conn, subscription_name, strlen(subscription_name));
 	printfPQExpBuffer(&query,
 					  "SELECT pglogical.pglogical_gen_slot_name(%s, %s, %s)",
-					  PQescapeLiteral(conn, dbname, strlen(dbname)),
-					  PQescapeLiteral(conn, provider_node_name,
-									  strlen(provider_node_name)),
-					  PQescapeLiteral(conn, subscription_name,
-									  strlen(subscription_name)));
+					  escaped_dbname,
+					  escaped_provider_node_name,
+					  escaped_subscription_name);
+	PQfreemem(escaped_dbname);
+	PQfreemem(escaped_provider_node_name);
+	PQfreemem(escaped_subscription_name);
+	escaped_dbname = NULL;
+	escaped_provider_node_name = NULL;
+	escaped_subscription_name = NULL;
 
 	res = PQexec(conn, query.data);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -823,9 +835,12 @@ initialize_replication_slot(PGconn *conn, char *dbname,
 	resetPQExpBuffer(&query);
 
 	/* Check if the current slot exists. */
+	escaped_slot_name = PQescapeLiteral(conn, slot_name, strlen(slot_name));
 	printfPQExpBuffer(&query,
 					  "SELECT 1 FROM pg_catalog.pg_replication_slots WHERE slot_name = %s",
-					  PQescapeLiteral(conn, slot_name, strlen(slot_name)));
+					  escaped_slot_name);
+	PQfreemem(escaped_slot_name);
+	escaped_slot_name = NULL;
 
 	res = PQexec(conn, query.data);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -844,9 +859,12 @@ initialize_replication_slot(PGconn *conn, char *dbname,
 		print_msg(VERBOSITY_VERBOSE,
 				  _("Droping existing slot %s ...\n"), slot_name);
 
+		escaped_slot_name = PQescapeLiteral(conn, slot_name, strlen(slot_name));
 		printfPQExpBuffer(&query,
 						  "SELECT pg_catalog.pg_drop_replication_slot(%s)",
-						  PQescapeLiteral(conn, slot_name, strlen(slot_name)));
+						  escaped_slot_name);
+		PQfreemem(escaped_slot_name);
+		escaped_slot_name = NULL;
 
 		res = PQexec(conn, query.data);
 		if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -858,9 +876,12 @@ initialize_replication_slot(PGconn *conn, char *dbname,
 	resetPQExpBuffer(&query);
 
 	/* And finally, create the slot. */
+	escaped_slot_name = PQescapeLiteral(conn, slot_name, strlen(slot_name));
 	appendPQExpBuffer(&query, "SELECT pg_create_logical_replication_slot(%s, '%s');",
-					  PQescapeLiteral(conn, slot_name, strlen(slot_name)),
+					  escaped_slot_name,
 					  "pglogical_output");
+	PQfreemem(escaped_slot_name);
+	escaped_slot_name = NULL;
 
 	res = PQexec(conn, query.data);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -922,9 +943,13 @@ extension_exists(PGconn *conn, const char *extname)
 	PQExpBuffer		query = createPQExpBuffer();
 	PGresult	   *res;
 	bool			ret;
+	char		   *escaped_extname = PQescapeLiteral(conn, extname, strlen(extname));
 
 	printfPQExpBuffer(query, "SELECT 1 FROM pg_catalog.pg_extension WHERE extname = %s;",
-					  PQescapeLiteral(conn, extname, strlen(extname)));
+					  escaped_extname);
+	PQfreemem(escaped_extname);
+	escaped_extname = NULL;
+
 	res = PQexec(conn, query->data);
 
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -1009,11 +1034,15 @@ initialize_replication_origin(PGconn *conn, char *origin_name, char *remote_lsn)
 {
 	PGresult   *res;
 	PQExpBuffer query = createPQExpBuffer();
+	char	   *escaped_origin_name = NULL;
+	char	   *escaped_remote_lsn = NULL;
 
 	if (PQserverVersion(conn) >= 90500)
 	{
-		printfPQExpBuffer(query, "SELECT pg_replication_origin_create(%s)",
-						  PQescapeLiteral(conn, origin_name, strlen(origin_name)));
+		escaped_origin_name = PQescapeLiteral(conn, origin_name, strlen(origin_name));
+		printfPQExpBuffer(query, "SELECT pg_replication_origin_create(%s)", escaped_origin_name);
+		PQfreemem(escaped_origin_name);
+		escaped_origin_name = NULL;
 
 		res = PQexec(conn, query->data);
 
@@ -1027,9 +1056,12 @@ initialize_replication_origin(PGconn *conn, char *origin_name, char *remote_lsn)
 
 		if (remote_lsn)
 		{
+			escaped_origin_name = PQescapeLiteral(conn, origin_name, strlen(origin_name));
 			printfPQExpBuffer(query, "SELECT pg_replication_origin_advance(%s, '%s')",
-							  PQescapeLiteral(conn, origin_name, strlen(origin_name)),
+							  escaped_origin_name,
 							  remote_lsn);
+			PQfreemem(escaped_origin_name);
+			escaped_origin_name = NULL;
 
 			res = PQexec(conn, query->data);
 
@@ -1044,9 +1076,15 @@ initialize_replication_origin(PGconn *conn, char *origin_name, char *remote_lsn)
 	}
 	else
 	{
+		escaped_origin_name = PQescapeLiteral(conn, origin_name, strlen(origin_name));
+		escaped_remote_lsn = PQescapeLiteral(conn, remote_lsn, strlen(remote_lsn));
 		printfPQExpBuffer(query, "INSERT INTO pglogical_origin.replication_origin (roident, roname, roremote_lsn) SELECT COALESCE(MAX(roident::int), 0) + 1, %s, %s FROM pglogical_origin.replication_origin",
-						  PQescapeLiteral(conn, origin_name, strlen(origin_name)),
-						  remote_lsn ? PQescapeLiteral(conn, remote_lsn, strlen(remote_lsn)) : "0");
+						  escaped_origin_name,
+						  remote_lsn ? escaped_remote_lsn : "0");
+		PQfreemem(escaped_origin_name);
+		PQfreemem(escaped_remote_lsn);
+		escaped_origin_name = NULL;
+		escaped_remote_lsn = NULL;
 
 		res = PQexec(conn, query->data);
 
@@ -1097,12 +1135,23 @@ pglogical_subscribe(PGconn *conn, char *subscriber_name, char *subscriber_dsn,
 	PQExpBufferData		query;
 	PQExpBufferData		repsets;
 	PGresult		   *res;
+	char			   *escaped_subscriber_name = NULL;
+	char			   *escaped_subscriber_dsn = NULL;
+	char			   *escaped_provider_dsn = NULL;
+	char			   *escaped_repsets_data = NULL;
 
 	initPQExpBuffer(&query);
+
+	escaped_subscriber_name = PQescapeLiteral(conn, subscriber_name, strlen(subscriber_name));
+	escaped_subscriber_dsn = PQescapeLiteral(conn, subscriber_dsn, strlen(subscriber_dsn));
 	printfPQExpBuffer(&query,
 					  "SELECT pglogical.create_node(node_name := %s, dsn := %s);",
-					  PQescapeLiteral(conn, subscriber_name, strlen(subscriber_name)),
-					  PQescapeLiteral(conn, subscriber_dsn, strlen(subscriber_dsn)));
+					  escaped_subscriber_name,
+					  escaped_subscriber_dsn);
+	PQfreemem(escaped_subscriber_name);
+	PQfreemem(escaped_subscriber_dsn);
+	escaped_subscriber_name = NULL;
+	escaped_subscriber_dsn = NULL;
 
 	res = PQexec(conn, query.data);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -1116,6 +1165,10 @@ pglogical_subscribe(PGconn *conn, char *subscriber_name, char *subscriber_dsn,
 	initPQExpBuffer(&repsets);
 
 	printfPQExpBuffer(&repsets, "{%s}", replication_sets);
+
+	escaped_subscriber_name = PQescapeLiteral(conn, subscriber_name, strlen(subscriber_name));
+	escaped_provider_dsn = PQescapeLiteral(conn, provider_dsn, strlen(provider_dsn));
+	escaped_repsets_data = PQescapeLiteral(conn, repsets.data, repsets.len);
 	printfPQExpBuffer(&query,
 					  "SELECT pglogical.create_subscription("
 					  "subscription_name := %s, provider_dsn := %s, "
@@ -1124,10 +1177,16 @@ pglogical_subscribe(PGconn *conn, char *subscriber_name, char *subscriber_dsn,
 					  "synchronize_structure := false, "
 					  "synchronize_data := false, "
 					  "force_text_transfer := '%s');",
-					  PQescapeLiteral(conn, subscriber_name, strlen(subscriber_name)),
-					  PQescapeLiteral(conn, provider_dsn, strlen(provider_dsn)),
-					  PQescapeLiteral(conn, repsets.data, repsets.len),
+					  escaped_subscriber_name,
+					  escaped_provider_dsn,
+					  escaped_repsets_data,
 					  apply_delay, (force_text_transfer ? "t" : "f"));
+	PQfreemem(escaped_subscriber_name);
+	PQfreemem(escaped_provider_dsn);
+	PQfreemem(escaped_repsets_data);
+	escaped_subscriber_name = NULL;
+	escaped_provider_dsn = NULL;
+	escaped_repsets_data = NULL;
 
 	res = PQexec(conn, query.data);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)

--- a/pglogical_create_subscriber.c
+++ b/pglogical_create_subscriber.c
@@ -949,9 +949,13 @@ install_extension(PGconn *conn, const char *extname)
 {
 	PQExpBuffer		query = createPQExpBuffer();
 	PGresult	   *res;
+	char           *escaped_extname = NULL;
 
-	printfPQExpBuffer(query, "CREATE EXTENSION IF NOT EXISTS %s;",
-					  PQescapeIdentifier(conn, extname, strlen(extname)));
+	escaped_extname = PQescapeIdentifier(conn, extname, strlen(extname));
+	printfPQExpBuffer(query, "CREATE EXTENSION IF NOT EXISTS %s;", escaped_extname);
+	PQfreemem(escaped_extname);
+	escaped_extname = NULL;
+
 	res = PQexec(conn, query->data);
 
 	if (PQresultStatus(res) != PGRES_COMMAND_OK)

--- a/pglogical_create_subscriber.c
+++ b/pglogical_create_subscriber.c
@@ -974,7 +974,7 @@ install_extension(PGconn *conn, const char *extname)
 {
 	PQExpBuffer		query = createPQExpBuffer();
 	PGresult	   *res;
-	char           *escaped_extname = NULL;
+	char		   *escaped_extname = NULL;
 
 	escaped_extname = PQescapeIdentifier(conn, extname, strlen(extname));
 	printfPQExpBuffer(query, "CREATE EXTENSION IF NOT EXISTS %s;", escaped_extname);
@@ -1077,14 +1077,17 @@ initialize_replication_origin(PGconn *conn, char *origin_name, char *remote_lsn)
 	else
 	{
 		escaped_origin_name = PQescapeLiteral(conn, origin_name, strlen(origin_name));
-		escaped_remote_lsn = PQescapeLiteral(conn, remote_lsn, strlen(remote_lsn));
+		escaped_remote_lsn = remote_lsn ? PQescapeLiteral(conn, remote_lsn, strlen(remote_lsn)) : NULL;
 		printfPQExpBuffer(query, "INSERT INTO pglogical_origin.replication_origin (roident, roname, roremote_lsn) SELECT COALESCE(MAX(roident::int), 0) + 1, %s, %s FROM pglogical_origin.replication_origin",
 						  escaped_origin_name,
 						  remote_lsn ? escaped_remote_lsn : "0");
 		PQfreemem(escaped_origin_name);
-		PQfreemem(escaped_remote_lsn);
 		escaped_origin_name = NULL;
-		escaped_remote_lsn = NULL;
+		if (escaped_remote_lsn)
+		{
+			PQfreemem(escaped_remote_lsn);
+			escaped_remote_lsn = NULL;
+		}
 
 		res = PQexec(conn, query->data);
 

--- a/pglogical_create_subscriber.c
+++ b/pglogical_create_subscriber.c
@@ -857,7 +857,7 @@ initialize_replication_slot(PGconn *conn, char *dbname,
 				slot_name);
 
 		print_msg(VERBOSITY_VERBOSE,
-				  _("Droping existing slot %s ...\n"), slot_name);
+				  _("Dropping existing slot %s ...\n"), slot_name);
 
 		escaped_slot_name = PQescapeLiteral(conn, slot_name, strlen(slot_name));
 		printfPQExpBuffer(&query,

--- a/pglogical_rpc.c
+++ b/pglogical_rpc.c
@@ -122,14 +122,14 @@ pg_logical_get_remote_repset_table(PGconn *conn, RangeVar *rv,
 	StringInfoData	query;
 	StringInfoData	repsetarr;
 	StringInfoData	relname;
-	char       *escaped_schemaname = NULL;
-	char       *escaped_relname = NULL;
-	char       *escaped_repset_name = NULL;
-	char       *escaped_relname_data = NULL;
-	
+	char	   *escaped_schemaname = NULL;
+	char	   *escaped_relname = NULL;
+	char	   *escaped_repset_name = NULL;
+	char	   *escaped_relname_data = NULL;
+
 
 	initStringInfo(&relname);
-	
+
 	escaped_schemaname = PQescapeIdentifier(conn, rv->schemaname, strlen(rv->schemaname));
 	escaped_relname = PQescapeIdentifier(conn, rv->relname, strlen(rv->relname));
 	appendStringInfo(&relname, "%s.%s", escaped_schemaname, escaped_relname);
@@ -368,7 +368,8 @@ pglogical_remote_function_exists(PGconn *conn, const char *nspname,
 	if (nargs >= 0)
 		appendStringInfo(&query,
 						 "   AND pronargs = '%d'", nargs);
-	if (argname != NULL) {
+	if (argname != NULL)
+	{
 		escaped_argname = PQescapeLiteral(conn, argname, strlen(argname));
 		appendStringInfo(&query,
 						 "   AND %s = ANY (proargnames)",

--- a/pglogical_rpc.c
+++ b/pglogical_rpc.c
@@ -43,6 +43,7 @@ pg_logical_get_remote_repset_tables(PGconn *conn, List *replication_sets)
 	bool		first = true;
 	StringInfoData	query;
 	StringInfoData	repsetarr;
+	char		   *escaped_repset_name = NULL;
 
 	initStringInfo(&repsetarr);
 	foreach (lc, replication_sets)
@@ -54,8 +55,10 @@ pg_logical_get_remote_repset_tables(PGconn *conn, List *replication_sets)
 		else
 			appendStringInfoChar(&repsetarr, ',');
 
-		appendStringInfo(&repsetarr, "%s",
-						 PQescapeLiteral(conn, repset_name, strlen(repset_name)));
+		escaped_repset_name = PQescapeLiteral(conn, repset_name, strlen(repset_name));
+		appendStringInfo(&repsetarr, "%s", escaped_repset_name);
+		PQfreemem(escaped_repset_name);
+		escaped_repset_name = NULL;
 	}
 
 	initStringInfo(&query);
@@ -121,6 +124,9 @@ pg_logical_get_remote_repset_table(PGconn *conn, RangeVar *rv,
 	StringInfoData	relname;
 	char       *escaped_schemaname = NULL;
 	char       *escaped_relname = NULL;
+	char       *escaped_repset_name = NULL;
+	char       *escaped_relname_data = NULL;
+	
 
 	initStringInfo(&relname);
 	
@@ -142,31 +148,39 @@ pg_logical_get_remote_repset_table(PGconn *conn, RangeVar *rv,
 		else
 			appendStringInfoChar(&repsetarr, ',');
 
-		appendStringInfo(&repsetarr, "%s",
-						 PQescapeLiteral(conn, repset_name, strlen(repset_name)));
+		escaped_repset_name = PQescapeLiteral(conn, repset_name, strlen(repset_name));
+		appendStringInfo(&repsetarr, "%s", escaped_repset_name);
+		PQfreemem(escaped_repset_name);
+		escaped_repset_name = NULL;
 	}
 
 	initStringInfo(&query);
 	if (pglogical_remote_function_exists(conn, "pglogical", "show_repset_table_info", 2, NULL))
 	{
 		/* PGLogical 2.0+ */
+		escaped_relname_data = PQescapeLiteral(conn, relname.data, relname.len);
 		appendStringInfo(&query,
 						 "SELECT i.relid, i.nspname, i.relname, i.att_list,"
 						 "       i.has_row_filter"
 						 "  FROM pglogical.show_repset_table_info(%s::regclass, ARRAY[%s]) i",
-						 PQescapeLiteral(conn, relname.data, relname.len),
+						 escaped_relname_data,
 						 repsetarr.data);
+		PQfreemem(escaped_relname_data);
+		escaped_relname_data = NULL;
 	}
 	else
 	{
 		/* PGLogical 1.x */
+		escaped_relname_data = PQescapeLiteral(conn, relname.data, relname.len);
 		appendStringInfo(&query,
 						 "SELECT r.oid AS relid, t.nspname, t.relname, ARRAY(SELECT attname FROM pg_attribute WHERE attrelid = r.oid AND NOT attisdropped AND attnum > 0) AS att_list,"
 						 "       false AS has_row_filter"
 						 "  FROM pglogical.tables t, pg_catalog.pg_class r, pg_catalog.pg_namespace n"
 						 " WHERE r.oid = %s::regclass AND t.set_name = ANY(ARRAY[%s]) AND r.relname = t.relname AND n.oid = r.relnamespace AND n.nspname = t.nspname",
-						 PQescapeLiteral(conn, relname.data, relname.len),
+						 escaped_relname_data,
 						 repsetarr.data);
+		PQfreemem(escaped_relname_data);
+		escaped_relname_data = NULL;
 	}
 
 	res = PQexec(conn, query.data);
@@ -336,6 +350,7 @@ pglogical_remote_function_exists(PGconn *conn, const char *nspname,
 	Oid				types[2] = { TEXTOID, TEXTOID };
 	bool			ret;
 	StringInfoData	query;
+	char		   *escaped_argname = NULL;
 
 	values[0] = proname;
 	values[1] = nspname;
@@ -353,10 +368,14 @@ pglogical_remote_function_exists(PGconn *conn, const char *nspname,
 	if (nargs >= 0)
 		appendStringInfo(&query,
 						 "   AND pronargs = '%d'", nargs);
-	if (argname != NULL)
+	if (argname != NULL) {
+		escaped_argname = PQescapeLiteral(conn, argname, strlen(argname));
 		appendStringInfo(&query,
 						 "   AND %s = ANY (proargnames)",
-						 PQescapeLiteral(conn, argname, strlen(argname)));
+						 escaped_argname);
+		PQfreemem(escaped_argname);
+		escaped_argname = NULL;
+	}
 
 	res = PQexecParams(conn, query.data, 2, types, values, NULL, NULL, 0);
 

--- a/pglogical_rpc.c
+++ b/pglogical_rpc.c
@@ -119,11 +119,18 @@ pg_logical_get_remote_repset_table(PGconn *conn, RangeVar *rv,
 	StringInfoData	query;
 	StringInfoData	repsetarr;
 	StringInfoData	relname;
+	char       *escaped_schemaname = NULL;
+	char       *escaped_relname = NULL;
 
 	initStringInfo(&relname);
-	appendStringInfo(&relname, "%s.%s",
-					 PQescapeIdentifier(conn, rv->schemaname, strlen(rv->schemaname)),
-					 PQescapeIdentifier(conn, rv->relname, strlen(rv->relname)));
+	
+	escaped_schemaname = PQescapeIdentifier(conn, rv->schemaname, strlen(rv->schemaname));
+	escaped_relname = PQescapeIdentifier(conn, rv->relname, strlen(rv->relname));
+	appendStringInfo(&relname, "%s.%s", escaped_schemaname, escaped_relname);
+	PQfreemem(escaped_schemaname);
+	PQfreemem(escaped_relname);
+	escaped_schemaname = NULL;
+	escaped_relname = NULL;
 
 	initStringInfo(&repsetarr);
 	foreach (lc, replication_sets)

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -528,6 +528,9 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 	PGresult   *res;
 	int			bytes;
 	char	   *copybuf;
+	char	   *escaped_attname = NULL;
+	char	   *escaped_nspname = NULL;
+	char	   *escaped_relname = NULL;
 	List	   *attnamelist;
 	ListCell   *lc;
 	bool		first;
@@ -552,9 +555,11 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 			first = false;
 		else
 			appendStringInfoString(&attlist, ",");
-		appendStringInfoString(&attlist,
-							   PQescapeIdentifier(origin_conn, attname,
-												  strlen(attname)));
+
+		escaped_attname = PQescapeIdentifier(origin_conn, attname, strlen(attname));
+		appendStringInfoString(&attlist, escaped_attname);
+		PQfreemem(escaped_attname);
+		escaped_attname = NULL;
 	}
 	MemoryContextSwitchTo(oldctx);
 	pglogical_relation_close(rel, AccessShareLock);
@@ -575,11 +580,14 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 		ListCell   *lc1;
 
 		initStringInfo(&relname);
-		appendStringInfo(&relname, "%s.%s",
-						 PQescapeIdentifier(origin_conn, remoterel->nspname,
-											strlen(remoterel->nspname)),
-						 PQescapeIdentifier(origin_conn, remoterel->relname,
-											strlen(remoterel->relname)));
+
+		escaped_nspname = PQescapeIdentifier(origin_conn, remoterel->nspname, strlen(remoterel->nspname));
+		escaped_relname = PQescapeIdentifier(origin_conn, remoterel->relname, strlen(remoterel->relname));
+		appendStringInfo(&relname, "%s.%s", escaped_nspname, escaped_relname);
+		PQfreemem(escaped_nspname);
+		PQfreemem(escaped_relname);
+		escaped_nspname = NULL;
+		escaped_relname = NULL;
 
 		initStringInfo(&repsetarr);
 		first = true;
@@ -607,11 +615,13 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 	else
 	{
 		/* Otherwise just copy the table. */
-		appendStringInfo(&query, "%s.%s ",
-						 PQescapeIdentifier(origin_conn, remoterel->nspname,
-											strlen(remoterel->nspname)),
-						 PQescapeIdentifier(origin_conn, remoterel->relname,
-											strlen(remoterel->relname)));
+		escaped_nspname = PQescapeIdentifier(origin_conn, remoterel->nspname, strlen(remoterel->nspname));
+		escaped_relname = PQescapeIdentifier(origin_conn, remoterel->relname, strlen(remoterel->relname));
+		appendStringInfo(&query, "%s.%s ", escaped_nspname, escaped_relname);
+		PQfreemem(escaped_nspname);
+		PQfreemem(escaped_relname);
+		escaped_nspname = NULL;
+		escaped_relname = NULL;
 
 		if (list_length(attnamelist))
 			appendStringInfo(&query, "(%s) ", attlist.data);
@@ -631,11 +641,15 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 
 	/* Build COPY FROM query. */
 	resetStringInfo(&query);
-	appendStringInfo(&query, "COPY %s.%s ",
-					 PQescapeIdentifier(origin_conn, remoterel->nspname,
-										strlen(remoterel->nspname)),
-					 PQescapeIdentifier(origin_conn, remoterel->relname,
-										strlen(remoterel->relname)));
+
+	escaped_nspname = PQescapeIdentifier(origin_conn, remoterel->nspname, strlen(remoterel->nspname));
+	escaped_relname = PQescapeIdentifier(origin_conn, remoterel->relname, strlen(remoterel->relname));
+	appendStringInfo(&query, "COPY %s.%s ", escaped_nspname, escaped_relname);
+	PQfreemem(escaped_nspname);
+	PQfreemem(escaped_relname);
+	escaped_nspname = NULL;
+	escaped_relname = NULL;
+
 	if (list_length(attnamelist))
 		appendStringInfo(&query, "(%s) ", attlist.data);
 	appendStringInfoString(&query, "FROM stdin");

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -385,6 +385,8 @@ start_copy_origin_tx(PGconn *conn, const char *snapshot)
 	{
 		s = PQescapeLiteral(conn, snapshot, strlen(snapshot));
 		appendStringInfo(&query, "SET TRANSACTION SNAPSHOT %s;\n", s);
+		PQfreemem(s);
+		s = NULL;
 	}
 
 	res = PQexec(conn, query.data);
@@ -423,6 +425,7 @@ start_copy_target_tx(PGconn *conn, const char *origin_name)
 						 "SELECT pg_catalog.pg_replication_origin_session_setup(%s);\n",
 						 s);
 		PQfreemem(s);
+		s = NULL;
 	}
 
 	appendStringInfoString(&query, setup_query);
@@ -531,6 +534,8 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 	char	   *escaped_attname = NULL;
 	char	   *escaped_nspname = NULL;
 	char	   *escaped_relname = NULL;
+	char	   *escaped_repset_name = NULL;
+	char	   *escaped_relname_data = NULL;
 	List	   *attnamelist;
 	ListCell   *lc;
 	bool		first;
@@ -600,17 +605,21 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 			else
 				appendStringInfoChar(&repsetarr, ',');
 
-			appendStringInfo(&repsetarr, "%s",
-							 PQescapeLiteral(origin_conn, repset_name,
-											 strlen(repset_name)));
+			escaped_repset_name = PQescapeLiteral(origin_conn, repset_name, strlen(repset_name));
+			appendStringInfo(&repsetarr, "%s", escaped_repset_name);
+			PQfreemem(escaped_repset_name);
+			escaped_repset_name = NULL;
 		}
 
+		escaped_relname_data = PQescapeLiteral(origin_conn, relname.data, relname.len);
 		appendStringInfo(&query,
 						 "(SELECT %s FROM pglogical.table_data_filtered(NULL::%s, %s::regclass, ARRAY[%s])) ",
 						 list_length(attnamelist) ? attlist.data : "*",
 						 relname.data,
-						 PQescapeLiteral(origin_conn, relname.data, relname.len),
+						 escaped_relname_data,
 						 repsetarr.data);
+		PQfreemem(escaped_relname_data);
+		escaped_relname_data = NULL;
 	}
 	else
 	{


### PR DESCRIPTION
- PQescapeIdentifier/PQescapeIdentifier use malloc to allocate, which requires PQfreemem to deallocate after used.
- Pointers are set to NULL to avoid being dangling in any cases.
