### PR TITLE
Fix sync worker hanging on Extension wait event after table resynchronization

### DIFF
--- a/expected/add_table.out
+++ b/expected/add_table.out
@@ -130,7 +130,7 @@ SELECT * FROM pglogical.replication_set_add_table('default', '"strange.schema-IS
 (1 row)
 
 \c :subscriber_dsn
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
  wait_for_table_sync_complete 
 ------------------------------
@@ -217,7 +217,7 @@ SELECT * FROM pglogical.alter_subscription_synchronize('test_subscription');
 (1 row)
 
 BEGIN;
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_nosync');
  wait_for_table_sync_complete 
 ------------------------------
@@ -255,7 +255,7 @@ SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscriptio
 (1 row)
 
 BEGIN;
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
  wait_for_table_sync_complete 
 ------------------------------
@@ -507,7 +507,7 @@ SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscriptio
 (1 row)
 
 BEGIN;
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'synctest');
  wait_for_table_sync_complete 
 ------------------------------

--- a/expected/add_table.out
+++ b/expected/add_table.out
@@ -130,7 +130,7 @@ SELECT * FROM pglogical.replication_set_add_table('default', '"strange.schema-IS
 (1 row)
 
 \c :subscriber_dsn
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
  wait_for_table_sync_complete 
 ------------------------------
@@ -217,7 +217,7 @@ SELECT * FROM pglogical.alter_subscription_synchronize('test_subscription');
 (1 row)
 
 BEGIN;
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_nosync');
  wait_for_table_sync_complete 
 ------------------------------
@@ -255,7 +255,7 @@ SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscriptio
 (1 row)
 
 BEGIN;
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
  wait_for_table_sync_complete 
 ------------------------------
@@ -263,13 +263,13 @@ SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publics
 (1 row)
 
 COMMIT;
-SELECT sync_kind, sync_subid, sync_nspname, sync_relname, sync_status IN ('y', 'r') FROM pglogical.local_sync_status ORDER BY 2,3,4;
- sync_kind | sync_subid |   sync_nspname    |    sync_relname    | ?column? 
------------+------------+-------------------+--------------------+----------
- d         | 3848008564 | public            | test_nosync        | t
- d         | 3848008564 | public            | test_publicschema  | t
- d         | 3848008564 | strange.schema-IS | test_strangeschema | t
- f         | 3848008564 |                   |                    | t
+SELECT sync_kind, sync_subid, sync_nspname, sync_relname, sync_status, sync_status IN ('y', 'r') FROM pglogical.local_sync_status ORDER BY 2,3,4;
+ sync_kind | sync_subid |   sync_nspname    |    sync_relname    | sync_status | ?column? 
+-----------+------------+-------------------+--------------------+-------------+----------
+ d         | 3848008564 | public            | test_nosync        | r           | t
+ d         | 3848008564 | public            | test_publicschema  | r           | t
+ d         | 3848008564 | strange.schema-IS | test_strangeschema | r           | t
+ f         | 3848008564 |                   |                    | r           | t
 (4 rows)
 
 SELECT * FROM public.test_publicschema;
@@ -282,10 +282,11 @@ SELECT * FROM public.test_publicschema;
 (4 rows)
 
 \x
-SELECT nspname, relname, status IN ('synchronized', 'replicating') FROM pglogical.show_subscription_table('test_subscription', 'test_publicschema');
+SELECT nspname, relname, status, status IN ('synchronized', 'replicating') FROM pglogical.show_subscription_table('test_subscription', 'test_publicschema');
 -[ RECORD 1 ]---------------
 nspname  | public
 relname  | test_publicschema
+status   | replicating
 ?column? | t
 
 \x
@@ -506,7 +507,7 @@ SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscriptio
 (1 row)
 
 BEGIN;
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'synctest');
  wait_for_table_sync_complete 
 ------------------------------

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -135,7 +135,7 @@ typedef struct PGLFlushPosition
 	XLogRecPtr remote_end;
 } PGLFlushPosition;
 
-static dlist_head lsn_mapping = DLIST_STATIC_INIT(lsn_mapping);
+dlist_head lsn_mapping = DLIST_STATIC_INIT(lsn_mapping);
 
 typedef struct ApplyExecState
 {
@@ -152,7 +152,7 @@ struct ActionErrCallbackArg
 	bool is_ddl_or_drop;
 };
 
-static struct ActionErrCallbackArg errcallback_arg;
+struct ActionErrCallbackArg errcallback_arg;
 static TransactionId remote_xid;
 
 static void multi_insert_finish(void);
@@ -1360,8 +1360,6 @@ apply_work(PGconn *streamConn)
 	{
 		int			rc;
 		int			r;
-		
-		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:
@@ -1382,22 +1380,37 @@ apply_work(PGconn *streamConn)
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
 
+		/* KRISHNA */
 		/* Periodic completion check for sync workers to handle race conditions */
-		if (MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_SYNC)
+		if (MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_SYNC &&
+			MyApplyWorker->replay_stop_lsn != InvalidXLogRecPtr)
 		{
 			static TimestampTz last_completion_check = 0;
+			static XLogRecPtr last_processed_lsn = InvalidXLogRecPtr;
 			TimestampTz now = GetCurrentTimestamp();
+			
+			/* Track the highest LSN we've processed */
+			if (last_received != InvalidXLogRecPtr && last_received > last_processed_lsn)
+				last_processed_lsn = last_received;
 			
 			/* Check every 5 seconds for completion */
 			if (TimestampDifferenceExceeds(last_completion_check, now, 5000))
 			{
-				XLogRecPtr current_lsn = replorigin_session_get_progress(false);
+				elog(LOG, "sync worker periodic check: target LSN %X/%X, last_processed %X/%X",
+					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
+					 (uint32)MyApplyWorker->replay_stop_lsn,
+					 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn);
 				
-				/* Check if we've reached our target */
-				if (current_lsn >= MyApplyWorker->replay_stop_lsn)
+				/* 
+				 * Check if we've reached our target using the same logic as handle_commit().
+				 * Use the tracked last_processed_lsn which represents the highest end_lsn
+				 * we've seen from processed messages.
+				 */
+				if (last_processed_lsn != InvalidXLogRecPtr && 
+					MyApplyWorker->replay_stop_lsn <= last_processed_lsn)
 				{
-					elog(LOG, "sync worker detected completion during periodic check, current LSN %X/%X >= target LSN %X/%X",
-						 (uint32)(current_lsn >> 32), (uint32)current_lsn,
+					elog(LOG, "sync worker detected completion during periodic check, processed LSN %X/%X >= target LSN %X/%X",
+						 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn,
 						 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
 						 (uint32)MyApplyWorker->replay_stop_lsn);
 					
@@ -1405,16 +1418,23 @@ apply_work(PGconn *streamConn)
 					set_table_sync_status(MyApplyWorker->subid,
 										  NameStr(MyPGLogicalWorker->worker.sync.nspname),
 										  NameStr(MyPGLogicalWorker->worker.sync.relname),
-										  SYNC_STATUS_SYNCDONE, current_lsn);
+										  SYNC_STATUS_SYNCDONE, last_processed_lsn);
 					CommitTransactionCommand();
 					
-					/* Exit apply_work() to trigger cleanup */
-					return;
+					/* Disconnect before calling pglogical_sync_worker_finish() */
+					PQfinish(applyconn);
+					
+					/* Finish the sync worker properly */
+					pglogical_sync_worker_finish();
+					
+					/* Exit gracefully with code 0 */
+					proc_exit(0);					
 				}
 				
 				last_completion_check = now;
 			}
-		}			
+		}
+		/* KRISHNA */
 
 		if (rc & WL_SOCKET_READABLE)
 			PQconsumeInput(applyconn);

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1382,6 +1382,40 @@ apply_work(PGconn *streamConn)
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
 
+		/* Periodic completion check for sync workers to handle race conditions */
+		if (MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_SYNC)
+		{
+			static TimestampTz last_completion_check = 0;
+			TimestampTz now = GetCurrentTimestamp();
+			
+			/* Check every 5 seconds for completion */
+			if (TimestampDifferenceExceeds(last_completion_check, now, 5000))
+			{
+				XLogRecPtr current_lsn = replorigin_session_get_progress(false);
+				
+				/* Check if we've reached our target */
+				if (current_lsn >= MyApplyWorker->replay_stop_lsn)
+				{
+					elog(LOG, "sync worker detected completion during periodic check, current LSN %X/%X >= target LSN %X/%X",
+						 (uint32)(current_lsn >> 32), (uint32)current_lsn,
+						 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
+						 (uint32)MyApplyWorker->replay_stop_lsn);
+					
+					StartTransactionCommand();
+					set_table_sync_status(MyApplyWorker->subid,
+										  NameStr(MyPGLogicalWorker->worker.sync.nspname),
+										  NameStr(MyPGLogicalWorker->worker.sync.relname),
+										  SYNC_STATUS_SYNCDONE, current_lsn);
+					CommitTransactionCommand();
+					
+					/* Exit apply_work() to trigger cleanup */
+					return;
+				}
+				
+				last_completion_check = now;
+			}
+		}			
+
 		if (rc & WL_SOCKET_READABLE)
 			PQconsumeInput(applyconn);
 

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1386,54 +1386,36 @@ apply_work(PGconn *streamConn)
 		if (MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_SYNC &&
 			MyApplyWorker->replay_stop_lsn != InvalidXLogRecPtr)
 		{
-			static TimestampTz last_completion_check = 0;
 			static XLogRecPtr last_processed_lsn = InvalidXLogRecPtr;
-			TimestampTz now = GetCurrentTimestamp();
 			
-			/* Track the highest LSN we've processed */
 			if (last_received != InvalidXLogRecPtr && last_received > last_processed_lsn)
 				last_processed_lsn = last_received;
 			
-			/* Check every 5 seconds for completion */
-			if (TimestampDifferenceExceeds(last_completion_check, now, 5000))
-			{
-				elog(LOG, "sync worker periodic check: target LSN %X/%X, last_processed %X/%X",
+			elog(DEBUG1, "sync worker periodic check: target LSN %X/%X, last_processed %X/%X",
 					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
 					 (uint32)MyApplyWorker->replay_stop_lsn,
 					 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn);
 				
-				/* 
-				 * Check if we've reached our target using the same logic as handle_commit().
-				 * Use the tracked last_processed_lsn which represents the highest end_lsn
-				 * we've seen from processed messages.
-				 */
-				if (last_processed_lsn != InvalidXLogRecPtr && 
-					MyApplyWorker->replay_stop_lsn <= last_processed_lsn)
-				{
-					elog(LOG, "sync worker detected completion during periodic check, processed LSN %X/%X >= target LSN %X/%X",
-						 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn,
-						 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
-						 (uint32)MyApplyWorker->replay_stop_lsn);
+			if (last_processed_lsn != InvalidXLogRecPtr && 
+				MyApplyWorker->replay_stop_lsn <= last_processed_lsn)
+			{
+				elog(LOG, "sync worker detected completion during periodic check, processed LSN %X/%X >= target LSN %X/%X",
+					 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn,
+					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
+					 (uint32)MyApplyWorker->replay_stop_lsn);
 					
-					StartTransactionCommand();
-					set_table_sync_status(MyApplyWorker->subid,
-										  NameStr(MyPGLogicalWorker->worker.sync.nspname),
-										  NameStr(MyPGLogicalWorker->worker.sync.relname),
-										  SYNC_STATUS_SYNCDONE, last_processed_lsn);
-					CommitTransactionCommand();
-					
-					/* Disconnect before calling pglogical_sync_worker_finish() */
-					PQfinish(applyconn);
-					
-					/* Finish the sync worker properly */
-					pglogical_sync_worker_finish();
-					
-					/* Exit gracefully with code 0 */
-					proc_exit(0);					
-				}
-				
-				last_completion_check = now;
+				StartTransactionCommand();
+				set_table_sync_status(MyApplyWorker->subid,
+						  NameStr(MyPGLogicalWorker->worker.sync.nspname),
+						  NameStr(MyPGLogicalWorker->worker.sync.relname),
+						  SYNC_STATUS_SYNCDONE, last_processed_lsn);
+				CommitTransactionCommand();
+				XLogFlush(GetXLogWriteRecPtr());	
+				PQfinish(applyconn);
+				pglogical_sync_worker_finish();
+				proc_exit(0);					
 			}
+				
 		}
 
 		if (rc & WL_SOCKET_READABLE)

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1382,40 +1382,42 @@ apply_work(PGconn *streamConn)
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
 
-		/* Periodic completion check for sync workers to handle race conditions */
+		/*
+		* Completion check for tablesync workers:
+		* If we've already applied up to replay_stop_lsn, mark SYNC_STATUS_SYNCDONE
+		* and exit, without waiting for a new commit record from the publisher.
+		*/
 		if (MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_SYNC &&
 			MyApplyWorker->replay_stop_lsn != InvalidXLogRecPtr)
 		{
 			static XLogRecPtr last_processed_lsn = InvalidXLogRecPtr;
-			
+
 			if (last_received != InvalidXLogRecPtr && last_received > last_processed_lsn)
 				last_processed_lsn = last_received;
-			
-			elog(DEBUG1, "sync worker periodic check: target LSN %X/%X, last_processed %X/%X",
-					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
+
+			elog(DEBUG1, "sync worker check: target LSN %X/%X, last_processed %X/%X",
+					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32),
 					 (uint32)MyApplyWorker->replay_stop_lsn,
 					 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn);
-				
-			if (last_processed_lsn != InvalidXLogRecPtr && 
+
+			if (last_processed_lsn != InvalidXLogRecPtr &&
 				MyApplyWorker->replay_stop_lsn <= last_processed_lsn)
 			{
-				elog(LOG, "sync worker detected completion during periodic check, processed LSN %X/%X >= target LSN %X/%X",
+				elog(DEBUG1, "sync worker completion: processed LSN %X/%X >= target LSN %X/%X",
 					 (uint32)(last_processed_lsn >> 32), (uint32)last_processed_lsn,
-					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32), 
+					 (uint32)(MyApplyWorker->replay_stop_lsn >> 32),
 					 (uint32)MyApplyWorker->replay_stop_lsn);
-					
 				StartTransactionCommand();
 				set_table_sync_status(MyApplyWorker->subid,
 						  NameStr(MyPGLogicalWorker->worker.sync.nspname),
 						  NameStr(MyPGLogicalWorker->worker.sync.relname),
 						  SYNC_STATUS_SYNCDONE, last_processed_lsn);
 				CommitTransactionCommand();
-				XLogFlush(GetXLogWriteRecPtr());	
+				XLogFlush(GetXLogWriteRecPtr());
 				PQfinish(applyconn);
 				pglogical_sync_worker_finish();
-				proc_exit(0);					
+				proc_exit(0);
 			}
-				
 		}
 
 		if (rc & WL_SOCKET_READABLE)

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1361,7 +1361,7 @@ apply_work(PGconn *streamConn)
 		int			rc;
 		int			r;
 
-                CHECK_FOR_INTERRUPTS();
+		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:
@@ -1382,7 +1382,6 @@ apply_work(PGconn *streamConn)
 		if (rc & WL_POSTMASTER_DEATH)
 			proc_exit(1);
 
-		/* KRISHNA */
 		/* Periodic completion check for sync workers to handle race conditions */
 		if (MyPGLogicalWorker->worker_type == PGLOGICAL_WORKER_SYNC &&
 			MyApplyWorker->replay_stop_lsn != InvalidXLogRecPtr)
@@ -1436,7 +1435,6 @@ apply_work(PGconn *streamConn)
 				last_completion_check = now;
 			}
 		}
-		/* KRISHNA */
 
 		if (rc & WL_SOCKET_READABLE)
 			PQconsumeInput(applyconn);

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -135,7 +135,7 @@ typedef struct PGLFlushPosition
 	XLogRecPtr remote_end;
 } PGLFlushPosition;
 
-dlist_head lsn_mapping = DLIST_STATIC_INIT(lsn_mapping);
+static dlist_head lsn_mapping = DLIST_STATIC_INIT(lsn_mapping);
 
 typedef struct ApplyExecState
 {
@@ -152,7 +152,7 @@ struct ActionErrCallbackArg
 	bool is_ddl_or_drop;
 };
 
-struct ActionErrCallbackArg errcallback_arg;
+static struct ActionErrCallbackArg errcallback_arg;
 static TransactionId remote_xid;
 
 static void multi_insert_finish(void);
@@ -1360,6 +1360,8 @@ apply_work(PGconn *streamConn)
 	{
 		int			rc;
 		int			r;
+
+		CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -1361,7 +1361,7 @@ apply_work(PGconn *streamConn)
 		int			rc;
 		int			r;
 
-		CHECK_FOR_INTERRUPTS();
+                CHECK_FOR_INTERRUPTS();
 
 		/*
 		 * Background workers mustn't call usleep() or any direct equivalent:

--- a/sql/add_table.sql
+++ b/sql/add_table.sql
@@ -57,7 +57,7 @@ SELECT * FROM pglogical.replication_set_add_table('default', '"strange.schema-IS
 
 
 \c :subscriber_dsn
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', '"strange.schema-IS".test_strangeschema');
 RESET statement_timeout;
@@ -97,7 +97,7 @@ SELECT * FROM "strange.schema-IS".test_strangeschema;
 SELECT * FROM pglogical.alter_subscription_synchronize('test_subscription');
 
 BEGIN;
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_nosync');
 COMMIT;
 
@@ -111,16 +111,16 @@ SELECT * FROM public.test_publicschema;
 SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscription', 'test_publicschema');
 
 BEGIN;
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
 COMMIT;
 
-SELECT sync_kind, sync_subid, sync_nspname, sync_relname, sync_status IN ('y', 'r') FROM pglogical.local_sync_status ORDER BY 2,3,4;
+SELECT sync_kind, sync_subid, sync_nspname, sync_relname, sync_status, sync_status IN ('y', 'r') FROM pglogical.local_sync_status ORDER BY 2,3,4;
 
 SELECT * FROM public.test_publicschema;
 
 \x
-SELECT nspname, relname, status IN ('synchronized', 'replicating') FROM pglogical.show_subscription_table('test_subscription', 'test_publicschema');
+SELECT nspname, relname, status, status IN ('synchronized', 'replicating') FROM pglogical.show_subscription_table('test_subscription', 'test_publicschema');
 \x
 
 BEGIN;
@@ -254,7 +254,7 @@ INSERT INTO synctest VALUES (2, '2');
 SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscription', 'synctest');
 
 BEGIN;
-SET statement_timeout = '180s';
+SET statement_timeout = '60s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'synctest');
 COMMIT;
 

--- a/sql/add_table.sql
+++ b/sql/add_table.sql
@@ -57,7 +57,7 @@ SELECT * FROM pglogical.replication_set_add_table('default', '"strange.schema-IS
 
 
 \c :subscriber_dsn
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', '"strange.schema-IS".test_strangeschema');
 RESET statement_timeout;
@@ -97,7 +97,7 @@ SELECT * FROM "strange.schema-IS".test_strangeschema;
 SELECT * FROM pglogical.alter_subscription_synchronize('test_subscription');
 
 BEGIN;
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_nosync');
 COMMIT;
 
@@ -111,7 +111,7 @@ SELECT * FROM public.test_publicschema;
 SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscription', 'test_publicschema');
 
 BEGIN;
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'test_publicschema');
 COMMIT;
 
@@ -254,7 +254,7 @@ INSERT INTO synctest VALUES (2, '2');
 SELECT * FROM pglogical.alter_subscription_resynchronize_table('test_subscription', 'synctest');
 
 BEGIN;
-SET statement_timeout = '60s';
+SET statement_timeout = '180s';
 SELECT pglogical.wait_for_table_sync_complete('test_subscription', 'synctest');
 COMMIT;
 


### PR DESCRIPTION
## Problem

After performing `pglogical.alter_subscription_resynchronize_table` operations, sync workers get stuck waiting on "Extension" wait events indefinitely. The table status shows as `catchup`(u) but the sync worker remains idle until a dummy transaction is performed on the source database.

### Symptoms
- Sync worker shows "Extension" wait event in `pg_stat_activity`
- Table status remains in `catchup` state despite successful data synchronization
- Worker only progresses when new WAL activity occurs on source database (e.g., dummy/heartbeat transactions)
- No error messages, just indefinite waiting

### Cause
The issue appears due to a race condition in the sync completion logic:

1. When a sync worker completes its initial data copy and moves to SYNC_STATUS_SYNCWAIT ('w'), the apply worker in process_syncing_tables() sets the status to SYNC_STATUS_CATCHUP ('u') and updates the replay_stop_lsn().
2. The sync worker then enters `apply_work()` to catch up to the target LSN. However, the transition from SYNC_STATUS_CATCHUP ('u') to SYNC_STATUS_SYNCDONE ('y') only happens in the apply worker's handle_commit() function when:
    - The sync worker reaches its replay_stop_lsn
    - AND a commit message is processed
3. When the publisher database is idle: If the sync worker has already caught up to the target LSN but there are no new transactions (commits) coming from the source database, the status remains in 'u' and never transitions 'y'.

The problem occurs because the sync worker relies on receiving WAL messages to trigger completion checks, but if the source database has no activity, no messages are sent, leaving the worker stuck.

### Changes Made

1. **Added completion check in `apply_work()`**: sync workers check if their current LSN has reached or exceeded the target `replay_stop_lsn`

2. **Clean exit path**: When completion is detected, worker updates table status to `SYNC_STATUS_SYNCDONE` and exits cleanly
