### PR TITLE
Fix resource leaks

### DIFF
--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -565,6 +565,10 @@ handle_insert(StringInfo s)
 		{
 			apply_api.multi_insert_add_tuple(rel, &newtup);
 			last_insert_rel_cnt++;
+
+			pglogical_relation_close(rel, NoLock);
+			PopActiveSnapshot();
+			CommandCounterIncrement();
 			return;
 		}
 	}

--- a/pglogical_output_plugin.c
+++ b/pglogical_output_plugin.c
@@ -630,6 +630,7 @@ pglogical_change_filter(PGLogicalOutputData *data, Relation relation,
 		HeapTuple		newtup = change->data.tp.newtuple ?
 			&change->data.tp.newtuple->tuple : NULL;
 #endif
+		bool			result;
 
 		/* Skip empty changes. */
 		if (!newtup && !oldtup)
@@ -646,6 +647,7 @@ pglogical_change_filter(PGLogicalOutputData *data, Relation relation,
 		ExecStoreHeapTuple(newtup ? newtup : oldtup, econtext->ecxt_scantuple, false);
 
 		/* Next try the row_filters if there are any. */
+		result = true;
 		foreach (lc, tblinfo->row_filter)
 		{
 			Node	   *row_filter = (Node *) lfirst(lc);
@@ -656,17 +658,19 @@ pglogical_change_filter(PGLogicalOutputData *data, Relation relation,
 			res = ExecEvalExpr(exprstate, econtext, &isnull, NULL);
 
 			/* NULL is same as false for our use. */
-			if (isnull)
-				return false;
-
-			if (!DatumGetBool(res))
-				return false;
+			if (isnull || !DatumGetBool(res))
+			{
+				result = false;
+				break;
+			}
 		}
 
 		ExecDropSingleTupleTableSlot(econtext->ecxt_scantuple);
 		FreeExecutorState(estate);
 
 		PopActiveSnapshot();
+		if (!result)
+			return false;
 	}
 
 	/* Make sure caller is aware of any attribute filter. */


### PR DESCRIPTION
A few functions failed to release resources in early returns. I noticed the one with row filters while working on snapshot management changes in PostgreSQL when I added an assertion that when a historic snapshot is free'd, it must not still be marked as active. The leaks in row filter processing are otherwise harmlesss AFAICS, but if a lot of rows are filtered out, the resource owner holding all the resources can grow very large.

The other leak is with multi-inserts to a table. I'm not sure what the effect of that is, I found it by searching for other uses of PushActiveSnapshot.