### PR TITLE
Support PostgreSQL 19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ EXTRA_CLEAN += compat94/pglogical_compat.o compat95/pglogical_compat.o \
 			   compat16/pglogical_compat.o compat16/pglogical_compat.bc \
 			   compat17/pglogical_compat.o compat17/pglogical_compat.bc \
 			   compat18/pglogical_compat.o compat18/pglogical_compat.bc \
+			   compat19/pglogical_compat.o compat19/pglogical_compat.bc \
 			   pglogical_create_subscriber.o
 
 # The # in #define is taken as a comment, per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=142043

--- a/compat19/pglogical_compat.c
+++ b/compat19/pglogical_compat.c
@@ -1,0 +1,12 @@
+/*-------------------------------------------------------------------------
+ *
+ * pglogical_compat.c
+ *              compatibility functions (mainly with different PG versions)
+ *
+ * Copyright (c) 2015, PostgreSQL Global Development Group
+ *
+ * IDENTIFICATION
+ *              pglogical_compat.c
+ *
+ *-------------------------------------------------------------------------
+ */

--- a/compat19/pglogical_compat.h
+++ b/compat19/pglogical_compat.h
@@ -1,0 +1,189 @@
+#ifndef PG_LOGICAL_COMPAT_H
+#define PG_LOGICAL_COMPAT_H
+
+#include "access/amapi.h"
+#include "access/heapam.h"
+#include "access/table.h"
+#include "access/tableam.h"
+#include "utils/varlena.h"
+
+#define WaitLatchOrSocket(latch, wakeEvents, sock, timeout) \
+	WaitLatchOrSocket(latch, wakeEvents, sock, timeout, PG_WAIT_EXTENSION)
+
+#define WaitLatch(latch, wakeEvents, timeout) \
+	WaitLatch(latch, wakeEvents, timeout, PG_WAIT_EXTENSION)
+
+#define GetCurrentIntegerTimestamp() GetCurrentTimestamp()
+
+#define pg_analyze_and_rewrite(parsetree, query_string, paramTypes, numParams) \
+	pg_analyze_and_rewrite_fixedparams(parsetree, query_string, paramTypes, numParams, NULL)
+
+#define CreateCommandTag(raw_parsetree) \
+	CreateCommandTag(raw_parsetree->stmt)
+
+#define ExecAlterExtensionStmt(stmt) \
+	ExecAlterExtensionStmt(NULL, stmt)
+
+#undef ExecEvalExpr
+#define ExecEvalExpr(expr, econtext, isNull, isDone) \
+	((*(expr)->evalfunc) (expr, econtext, isNull))
+
+#define Form_pg_sequence Form_pg_sequence_data
+
+#define InitResultRelInfo(resultRelInfo, resultRelationDesc, resultRelationIndex, instrument_options) \
+	InitResultRelInfo(resultRelInfo, resultRelationDesc, resultRelationIndex, NULL, instrument_options)
+
+#define ExecARUpdateTriggers(estate, relinfo, tupleid, fdw_trigtuple, newslot, recheckIndexes) \
+	ExecARUpdateTriggers(estate, relinfo, NULL, NULL, tupleid, fdw_trigtuple, newslot, recheckIndexes, NULL, false)
+
+#define ExecARInsertTriggers(estate, relinfo, slot, recheckIndexes) \
+	ExecARInsertTriggers(estate, relinfo, slot, recheckIndexes, NULL)
+
+#define ExecARDeleteTriggers(estate, relinfo, tupleid, fdw_trigtuple) \
+	ExecARDeleteTriggers(estate, relinfo, tupleid, fdw_trigtuple, NULL, false)
+
+#define makeDefElem(name, arg) makeDefElem(name, arg, -1)
+
+#define PGLstandard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, sentToRemote, qc) \
+	standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc)
+
+#define PGLnext_ProcessUtility_hook(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, sentToRemote, qc) \
+	next_ProcessUtility_hook(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc)
+
+#define PGLCreateTrigger(stmt, queryString, relOid, refRelOid, constraintOid, indexOid, isInternal) \
+	CreateTrigger(stmt, queryString, relOid, refRelOid, constraintOid, indexOid, InvalidOid, InvalidOid, NULL, isInternal, false);
+
+#define	PGLDoCopy(stmt, queryString, processed) \
+	do \
+	{ \
+		ParseState* pstate = make_parsestate(NULL); \
+		DoCopy(pstate, stmt, -1, 0, processed); \
+		free_parsestate(pstate); \
+	} while (false);
+
+#define PGLReplicationSlotCreate(name, db_specific, persistency) ReplicationSlotCreate(name, db_specific, persistency)
+
+#ifndef rbtxn_has_catalog_changes
+#define rbtxn_has_catalog_changes(txn) (txn->has_catalog_changes)
+#endif
+
+/* ad7dbee368a */
+#define ExecInitExtraTupleSlot(estate) \
+	ExecInitExtraTupleSlot(estate, NULL, &TTSOpsHeapTuple)
+
+#define ACL_OBJECT_RELATION OBJECT_TABLE
+#define ACL_OBJECT_SEQUENCE OBJECT_SEQUENCE
+
+#define DatumGetJsonb DatumGetJsonbP
+
+#define pgl_heap_attisnull(tup, attnum, tupledesc) \
+	heap_attisnull(tup, attnum, tupledesc)
+
+/* 2a10fdc4307a667883f7a3369cb93a721ade9680 */
+#define getObjectDescription(object) getObjectDescription(object, false)
+
+/* e997a0c642860a96df0151cbeccfecbdf0450d08 */
+#define GetFlushRecPtr() GetFlushRecPtr(NULL)
+
+/* 216a784829c2c5f03ab0c43e009126cbb819e9b2 */
+#define PGLreplorigin_session_setup(node) replorigin_session_setup(node, 0)
+
+/* 70b42f2790292cc30aa07563f343f7ba6749af01 */
+#define EvalPlanQualInit(epqstate, parentestate, subplan, auxrowmarks, epqParam) \
+	EvalPlanQualInit(epqstate, parentestate, subplan, auxrowmarks, epqParam, NIL)
+
+/* 6a72c42fd5af7ada49584694f543eb06dddb4a87 */
+#define MemoryContextResetAndDeleteChildren(ctx) MemoryContextReset(ctx)
+
+/* 75680c3d805e2323cd437ac567f0677fdfc7b680 */
+#define SPI_push() ((void) 0)
+#define SPI_pop()  ((void) 0)
+#define tuplestore_donestoring(state)  ((void) 0)
+
+/* 89e5ef7e21812916c9cf9fcf56e45f0f74034656 */
+typedef enum ObjectClass
+{
+   OCLASS_CLASS,               /* pg_class */
+   OCLASS_PROC,                /* pg_proc */
+   OCLASS_TYPE,                /* pg_type */
+   OCLASS_CAST,                /* pg_cast */
+   OCLASS_COLLATION,           /* pg_collation */
+   OCLASS_CONSTRAINT,          /* pg_constraint */
+   OCLASS_CONVERSION,          /* pg_conversion */
+   OCLASS_DEFAULT,             /* pg_attrdef */
+   OCLASS_LANGUAGE,            /* pg_language */
+   OCLASS_LARGEOBJECT,         /* pg_largeobject */
+   OCLASS_OPERATOR,            /* pg_operator */
+   OCLASS_OPCLASS,             /* pg_opclass */
+   OCLASS_OPFAMILY,            /* pg_opfamily */
+   OCLASS_AM,                  /* pg_am */
+   OCLASS_AMOP,                /* pg_amop */
+   OCLASS_AMPROC,              /* pg_amproc */
+   OCLASS_REWRITE,             /* pg_rewrite */
+   OCLASS_TRIGGER,             /* pg_trigger */
+   OCLASS_SCHEMA,              /* pg_namespace */
+   OCLASS_STATISTIC_EXT,       /* pg_statistic_ext */
+   OCLASS_TSPARSER,            /* pg_ts_parser */
+   OCLASS_TSDICT,              /* pg_ts_dict */
+   OCLASS_TSTEMPLATE,          /* pg_ts_template */
+   OCLASS_TSCONFIG,            /* pg_ts_config */
+   OCLASS_ROLE,                /* pg_authid */
+   OCLASS_ROLE_MEMBERSHIP,     /* pg_auth_members */
+   OCLASS_DATABASE,            /* pg_database */
+   OCLASS_TBLSPACE,            /* pg_tablespace */
+   OCLASS_FDW,                 /* pg_foreign_data_wrapper */
+   OCLASS_FOREIGN_SERVER,      /* pg_foreign_server */
+   OCLASS_USER_MAPPING,        /* pg_user_mapping */
+   OCLASS_DEFACL,              /* pg_default_acl */
+   OCLASS_EXTENSION,           /* pg_extension */
+   OCLASS_EVENT_TRIGGER,       /* pg_event_trigger */
+   OCLASS_PARAMETER_ACL,       /* pg_parameter_acl */
+   OCLASS_POLICY,              /* pg_policy */
+   OCLASS_PUBLICATION,         /* pg_publication */
+   OCLASS_PUBLICATION_NAMESPACE,   /* pg_publication_namespace */
+   OCLASS_PUBLICATION_REL,     /* pg_publication_rel */
+   OCLASS_SUBSCRIPTION,        /* pg_subscription */
+   OCLASS_TRANSFORM            /* pg_transform */
+} ObjectClass;
+
+#define LAST_OCLASS        OCLASS_TRANSFORM
+
+/*
+ * 27c7c11366f72b1933e298481954a24c742036de added is_merge_update, which is
+ * false for us just like in core execReplication.c.
+ */
+#define ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple) \
+	ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, NULL, NULL, NULL, false)
+#define ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot) \
+	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot, NULL, NULL, false)
+
+/* cbc127917e04a978a788b8bc9d35a70244396d5b added unpruned_relids */
+#define ExecInitRangeTable(estate, rangeTable, permInfos) \
+	ExecInitRangeTable(estate, rangeTable, permInfos, bms_make_singleton(1))
+
+/* 1fdbca159e0055fefc0b391ec09520d0b3bd9248 did some renames */
+#define RepOriginId ReplOriginId
+#define InvalidRepOriginId InvalidReplOriginId
+
+/* 8f1e2dfe033e9a3236265c3b9f61bd226f4a8f54 some global variables were moved into a struct */
+#define replorigin_session_origin replorigin_xact_state.origin
+#define replorigin_session_origin_lsn replorigin_xact_state.origin_lsn
+#define replorigin_session_origin_timestamp replorigin_xact_state.origin_timestamp
+
+/* dcd8cc1c852cac4e65d336a79afb6b9eb9700ae1 added "flags" param */
+#define index_beginscan(heapRelation, indexRelation, snapshot, nkeys, norderbys) \
+	index_beginscan(heapRelation, indexRelation, snapshot, NULL, nkeys, norderbys, SO_NONE)
+#define table_beginscan(rel, snapshot, nkeys, key) \
+	table_beginscan(rel, snapshot, nkeys, key, SO_NONE)
+
+/* b7271aa1d71acda712a372213633fdb55c1465c1 */
+#define ExecInsertIndexTuples(resultRelInfo, slot, estate, update, noDupErr, specConflict, arbiterIndexes) \
+	ExecInsertIndexTuples(resultRelInfo, estate, \
+		((update) ? EIIT_IS_UPDATE : 0) | ((noDupErr) ? EIIT_NO_DUPE_ERROR : 0), \
+		slot, arbiterIndexes, specConflict)
+
+/* 137d05df2f2014c584b229310b8635fa6a8572ba */
+#define AssertVariableIsOfType(varname, typename) \
+	StaticAssertVariableIsOfType(varname, typename)
+
+#endif

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@ If you don’t have PostgreSQL already:
     - PostgreSQL 16: `yum install postgresql16-server postgresql16-contrib`
     - PostgreSQL 17: `yum install postgresql17-server postgresql17-contrib`
     - PostgreSQL 18: `yum install postgresql18-server postgresql18-contrib`
+    - PostgreSQL 19: `yum install postgresql19-server postgresql19-contrib`
 
 ##### Installation
 
@@ -107,6 +108,7 @@ You can proceed to install pglogical for your PostgreSQL version:
  - PostgreSQL 16: `yum install pglogical_16`
  - PostgreSQL 17: `yum install pglogical_17`
  - PostgreSQL 18: `yum install pglogical_18`
+ - PostgreSQL 19: `yum install pglogical_19`
 
 #### Installing pglogical with APT
 
@@ -128,6 +130,7 @@ Debian (e.g. Ubuntu).
     - PostgreSQL 16: `sudo apt-get install postgresql-16`
     - PostgreSQL 17: `sudo apt-get install postgresql-17`
     - PostgreSQL 18: `sudo apt-get install postgresql-18`
+    - PostgreSQL 19: `sudo apt-get install postgresql-19`
 
 ##### Installation
 
@@ -144,6 +147,7 @@ Once pre-requisites are complete, installing pglogical is simply a matter of exe
  - PostgreSQL 16: `sudo apt-get install postgresql-16-pglogical`
  - PostgreSQL 17: `sudo apt-get install postgresql-17-pglogical`
  - PostgreSQL 18: `sudo apt-get install postgresql-18-pglogical`
+ - PostgreSQL 19: `sudo apt-get install postgresql-19-pglogical`
 
 ### From source code
 
@@ -161,9 +165,9 @@ install. You might need to use `sudo` for the install step.
 e.g. for a typical Fedora or RHEL 9 install, assuming you're using the
 [yum.postgresql.org](http://yum.postgresql.org) packages for PostgreSQL:
 
-    sudo dnf install postgresql17-devel
-    PATH=/usr/pgsql-17/bin:$PATH make clean all
-    sudo PATH=/usr/pgsql-17/bin:$PATH make install
+    sudo dnf install postgresql19-devel
+    PATH=/usr/pgsql-19/bin:$PATH make clean all
+    sudo PATH=/usr/pgsql-19/bin:$PATH make install
 
 ## Usage
 

--- a/pglogical.c
+++ b/pglogical.c
@@ -70,6 +70,7 @@ static const struct config_enum_entry PGLogicalConflictResolvers[] = {
 	{NULL, 0, false}
 };
 
+#if PG_VERSION_NUM < 190000
 /* copied fom guc.c */
 static const struct config_enum_entry server_message_level_options[] = {
 	{"debug", DEBUG2, true},
@@ -87,6 +88,7 @@ static const struct config_enum_entry server_message_level_options[] = {
 	{"panic", PANIC, false},
 	{NULL, 0, false}
 };
+#endif
 
 bool	pglogical_synchronous_commit = false;
 char   *pglogical_temp_directory = "";

--- a/pglogical_conflict.c
+++ b/pglogical_conflict.c
@@ -834,7 +834,7 @@ tuple_to_stringinfo(StringInfo s, TupleDesc tupdesc, HeapTuple tuple)
 
 		if (isnull)
 			outputstr = "(null)";
-		else if (typisvarlena && VARATT_IS_EXTERNAL_ONDISK(origval))
+		else if (typisvarlena && VARATT_IS_EXTERNAL_ONDISK(DatumGetPointer(origval)))
 			outputstr = "(unchanged-toast-datum)";
 		else if (typisvarlena)
 			val = PointerGetDatum(PG_DETOAST_DATUM(origval));

--- a/pglogical_functions.c
+++ b/pglogical_functions.c
@@ -1029,6 +1029,9 @@ pglogical_show_subscription_table(PG_FUNCTION_ARGS)
 	TupleDescInitEntry(tupdesc, (AttrNumber) 1, "nspname", TEXTOID, -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "relname", TEXTOID, -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 3, "status", TEXTOID, -1, 0);
+#if PG_VERSION_NUM >= 190000
+	TupleDescFinalize(tupdesc);
+#endif
 	tupdesc = BlessTupleDesc(tupdesc);
 
 	nspname = get_namespace_name(get_rel_namespace(reloid));
@@ -2340,6 +2343,9 @@ pglogical_xact_commit_timestamp_origin(PG_FUNCTION_ARGS)
 					   TIMESTAMPTZOID, -1, 0);
 	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "roident",
 					   OIDOID, -1, 0);
+#if PG_VERSION_NUM >= 190000
+	TupleDescFinalize(tupdesc);
+#endif
 	tupdesc = BlessTupleDesc(tupdesc);
 
 #ifdef HAVE_REPLICATION_ORIGINS

--- a/pglogical_manager.c
+++ b/pglogical_manager.c
@@ -16,12 +16,17 @@
 
 #include "access/xact.h"
 
+#if PG_VERSION_NUM < 190000
 #include "commands/dbcommands.h"
+#endif
 #include "commands/extension.h"
 
 #include "storage/ipc.h"
 #include "storage/proc.h"
 
+#if PG_VERSION_NUM >= 190000
+#include "utils/lsyscache.h"
+#endif
 #include "utils/memutils.h"
 #include "utils/resowner.h"
 #include "utils/timestamp.h"

--- a/pglogical_manager.c
+++ b/pglogical_manager.c
@@ -16,17 +16,13 @@
 
 #include "access/xact.h"
 
-#if PG_VERSION_NUM < 190000
 #include "commands/dbcommands.h"
-#endif
 #include "commands/extension.h"
 
 #include "storage/ipc.h"
 #include "storage/proc.h"
 
-#if PG_VERSION_NUM >= 190000
 #include "utils/lsyscache.h"
-#endif
 #include "utils/memutils.h"
 #include "utils/resowner.h"
 #include "utils/timestamp.h"

--- a/pglogical_output.c
+++ b/pglogical_output.c
@@ -17,6 +17,8 @@
 
 #include "replication/logical.h"
 
+#include "pglogical_compat.h"
+
 PG_MODULE_MAGIC;
 
 extern void		_PG_output_plugin_init(OutputPluginCallbacks *cb);

--- a/pglogical_proto_json.c
+++ b/pglogical_proto_json.c
@@ -70,6 +70,11 @@ pglogical_json_write_begin(StringInfo out, PGLogicalOutputData *data, ReorderBuf
 			(uint32)(txn->origin_lsn >> 32), (uint32)(txn->origin_lsn));
 #endif
 #if PG_VERSION_NUM >= 150000 && PG_VERSION_NUM < 190000
+		/*
+		 * In 15-18, commit_time is accessed via txn->xact_time.commit_time.
+		 * Commit 57d46dff9b0b converted xact_time to an anonymous union,
+		 * making commit_time directly accessible again.
+		 */
 		if (txn->xact_time.commit_time != 0)
 		appendStringInfo(out, ", \"commit_time\":\"%s\"",
 			timestamptz_to_str(txn->xact_time.commit_time));

--- a/pglogical_proto_json.c
+++ b/pglogical_proto_json.c
@@ -69,7 +69,7 @@ pglogical_json_write_begin(StringInfo out, PGLogicalOutputData *data, ReorderBuf
 		appendStringInfo(out, ", \"origin_lsn\":\"%X/%X\"",
 			(uint32)(txn->origin_lsn >> 32), (uint32)(txn->origin_lsn));
 #endif
-#if PG_VERSION_NUM >= 150000
+#if PG_VERSION_NUM >= 150000 && PG_VERSION_NUM < 190000
 		if (txn->xact_time.commit_time != 0)
 		appendStringInfo(out, ", \"commit_time\":\"%s\"",
 			timestamptz_to_str(txn->xact_time.commit_time));
@@ -229,8 +229,10 @@ typedef enum					/* type categories for datum_to_json */
 	JSONTYPE_OTHER				/* all else */
 } JsonTypeCategory;
 
+#if PG_VERSION_NUM < 190000
 static void composite_to_json(Datum composite, StringInfo result,
 				  bool use_line_feeds);
+#endif
 static void array_dim_to_json(StringInfo result, int dim, int ndims, int *dims,
 				  Datum *vals, bool *nulls, int *valcount,
 				  JsonTypeCategory tcategory, Oid outfuncoid,
@@ -573,6 +575,7 @@ array_to_json_internal(Datum array, StringInfo result, bool use_line_feeds)
 	pfree(nulls);
 }
 
+#if PG_VERSION_NUM < 190000
 /*
  * Turn a composite / record into JSON.
  */
@@ -641,6 +644,7 @@ composite_to_json(Datum composite, StringInfo result, bool use_line_feeds)
 	appendStringInfoChar(result, '}');
 	ReleaseTupleDesc(tupdesc);
 }
+#endif
 
 
 /*
@@ -684,7 +688,7 @@ json_write_tuple(StringInfo out, Relation rel, HeapTuple tuple,
 		 * them.
 		 */
 		if (!isnull[i] && att->attlen == -1 &&
-			VARATT_IS_EXTERNAL_ONDISK(values[i]))
+			VARATT_IS_EXTERNAL_ONDISK(DatumGetPointer(values[i])))
 			continue;
 
 		if (needsep)

--- a/pglogical_proto_native.c
+++ b/pglogical_proto_native.c
@@ -175,6 +175,11 @@ pglogical_write_begin(StringInfo out, PGLogicalOutputData *data,
 	/* fixed fields */
 	pq_sendint64(out, txn->final_lsn);
 #if PG_VERSION_NUM >= 150000 && PG_VERSION_NUM < 190000
+	/*
+	 * In 15-18, commit_time is accessed via txn->xact_time.commit_time.
+	 * Commit 57d46dff9b0b converted xact_time to an anonymous union, making
+	 * commit_time directly accessible again.
+	 */
 	pq_sendint64(out, txn->xact_time.commit_time);
 #else
 	pq_sendint64(out, txn->commit_time);
@@ -200,6 +205,11 @@ pglogical_write_commit(StringInfo out, PGLogicalOutputData *data,
 	pq_sendint64(out, commit_lsn);
 	pq_sendint64(out, txn->end_lsn);
 #if PG_VERSION_NUM >= 150000 && PG_VERSION_NUM < 190000
+	/*
+	 * In 15-18, commit_time is accessed via txn->xact_time.commit_time.
+	 * Commit 57d46dff9b0b converted xact_time to an anonymous union, making
+	 * commit_time directly accessible again.
+	 */
 	pq_sendint64(out, txn->xact_time.commit_time);
 #else
 	pq_sendint64(out, txn->commit_time);

--- a/pglogical_proto_native.c
+++ b/pglogical_proto_native.c
@@ -174,7 +174,7 @@ pglogical_write_begin(StringInfo out, PGLogicalOutputData *data,
 
 	/* fixed fields */
 	pq_sendint64(out, txn->final_lsn);
-#if PG_VERSION_NUM >= 150000
+#if PG_VERSION_NUM >= 150000 && PG_VERSION_NUM < 190000
 	pq_sendint64(out, txn->xact_time.commit_time);
 #else
 	pq_sendint64(out, txn->commit_time);
@@ -199,7 +199,7 @@ pglogical_write_commit(StringInfo out, PGLogicalOutputData *data,
 	/* send fixed fields */
 	pq_sendint64(out, commit_lsn);
 	pq_sendint64(out, txn->end_lsn);
-#if PG_VERSION_NUM >= 150000
+#if PG_VERSION_NUM >= 150000 && PG_VERSION_NUM < 190000
 	pq_sendint64(out, txn->xact_time.commit_time);
 #else
 	pq_sendint64(out, txn->commit_time);
@@ -402,7 +402,7 @@ pglogical_write_tuple(StringInfo out, PGLogicalOutputData *data,
 			pq_sendbyte(out, 'n');	/* null column */
 			continue;
 		}
-		else if (att->attlen == -1 && VARATT_IS_EXTERNAL_ONDISK(values[i]))
+		else if (att->attlen == -1 && VARATT_IS_EXTERNAL_ONDISK(DatumGetPointer(values[i])))
 		{
 			pq_sendbyte(out, 'u');	/* unchanged toast column */
 			continue;
@@ -447,7 +447,7 @@ pglogical_write_tuple(StringInfo out, PGLogicalOutputData *data,
 					char *data = DatumGetPointer(values[i]);
 
 					/* send indirect datums inline */
-					if (VARATT_IS_EXTERNAL_INDIRECT(values[i]))
+					if (VARATT_IS_EXTERNAL_INDIRECT(DatumGetPointer(values[i])))
 					{
 						struct varatt_indirect redirect;
 						VARATT_EXTERNAL_GET_POINTER(redirect, data);

--- a/pglogical_worker.c
+++ b/pglogical_worker.c
@@ -18,7 +18,9 @@
 
 #include "access/xact.h"
 
+#if PG_VERSION_NUM < 190000
 #include "commands/dbcommands.h"
+#endif
 
 #include "storage/ipc.h"
 #include "storage/proc.h"
@@ -26,6 +28,9 @@
 #include "storage/procarray.h"
 
 #include "utils/guc.h"
+#if PG_VERSION_NUM >= 190000
+#include "utils/lsyscache.h"
+#endif
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 

--- a/pglogical_worker.c
+++ b/pglogical_worker.c
@@ -18,9 +18,7 @@
 
 #include "access/xact.h"
 
-#if PG_VERSION_NUM < 190000
 #include "commands/dbcommands.h"
-#endif
 
 #include "storage/ipc.h"
 #include "storage/proc.h"
@@ -28,9 +26,7 @@
 #include "storage/procarray.h"
 
 #include "utils/guc.h"
-#if PG_VERSION_NUM >= 190000
 #include "utils/lsyscache.h"
-#endif
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 


### PR DESCRIPTION
It cleanly compiles (mostly) and pass regression tests.
Compilation warnings in `pglogical_sync.c`: `pglogical_sync_subscription()` are caused by nested use of `PG_ENSURE_ERROR_CLEANUP()` macro in combination with `-Wshadow=compatible-local` flag, which is default since PostgreSQL 16.

```
echo "# +++ regress install-check in  +++" && /usr/local/pgsql-19/lib/postgresql/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/local/pgsql-19/bin'    \
    --temp-config ./regress-postgresql.conf \
    --temp-instance=./tmp_check \
    --outputdir=./regression_output \
    --create-role=logical \
    preseed infofuncs init_fail init preseed_check basic extended conflict_secondary_unique toasted replication_set add_table matview bidirectional primary_key interfaces foreign_key functions copy sequence triggers parallel row_filter row_filter_sampling att_list column_filter apply_delay multiple_upstreams node_origin_cascade drop
# +++ regress install-check in  +++
# initializing database system by running initdb
# using temp instance on port 58928 with PID 990737
ok 1         - preseed                                    78 ms
ok 2         - infofuncs                                  58 ms
ok 3         - init_fail                                  96 ms
ok 4         - init                                      294 ms
ok 5         - preseed_check                              22 ms
ok 6         - basic                                    5132 ms
ok 7         - extended                                14660 ms
ok 8         - conflict_secondary_unique                2052 ms
ok 9         - toasted                                  3053 ms
ok 10        - replication_set                          1039 ms
ok 11        - add_table                               21087 ms
ok 12        - matview                                  4102 ms
ok 13        - bidirectional                            4286 ms
ok 14        - primary_key                             21393 ms
ok 15        - interfaces                               1241 ms
ok 16        - foreign_key                              1053 ms
ok 17        - functions                                7241 ms
ok 18        - copy                                     1036 ms
ok 19        - sequence                                   23 ms
ok 20        - triggers                                 6144 ms
ok 21        - parallel                                 2295 ms
ok 22        - row_filter                               9566 ms
ok 23        - row_filter_sampling                      2064 ms
ok 24        - att_list                                 3158 ms
ok 25        - column_filter                            2297 ms
ok 26        - apply_delay                              8332 ms
ok 27        - multiple_upstreams                       3339 ms
ok 28        - node_origin_cascade                      3395 ms
ok 29        - drop                                     1083 ms
1..29
# All 29 tests passed.
```
Close https://github.com/2ndQuadrant/pglogical/issues/517