### PR TITLE
Use libpqsrv_PGresult wrappers from PostgreSQL 19 libpq-be-fe.h.

### DIFF
--- a/pglogical.h
+++ b/pglogical.h
@@ -20,7 +20,38 @@
 #include "executor/executor.h"
 #include "miscadmin.h"
 
+/* v19+: always use libpqsrv_PGresult wrapping */
+#ifdef LIBPQ_FE_H
+#error included libpq-fe.h too early
+#endif
+#if PG_VERSION_NUM >= 190000
+#include "libpq/libpq-be-fe.h"
+/* Core PostgreSQL backend never uses these symbols, so it omits wrappers. */
+static inline libpqsrv_PGresult *
+libpqsrv_PQexec(PGconn *conn, const char *query)
+{
+	return libpqsrv_PQwrap(PQexec(conn, query));
+}
+static inline libpqsrv_PGresult *
+libpqsrv_PQexecParams(PGconn *conn,
+					  const char *command,
+					  int nParams,
+					  const Oid *paramTypes,
+					  const char *const *paramValues,
+					  const int *paramLengths,
+					  const int *paramFormats,
+					  int resultFormat)
+{
+	return libpqsrv_PQwrap(PQexecParams(conn, command, nParams,
+										paramTypes, paramValues,
+										paramLengths,
+										paramFormats, resultFormat));
+}
+#define PQexec libpqsrv_PQexec
+#define PQexecParams libpqsrv_PQexecParams
+#else
 #include "libpq-fe.h"
+#endif
 
 #include "pglogical_fe.h"
 #include "pglogical_node.h"

--- a/pglogical_apply.c
+++ b/pglogical_apply.c
@@ -13,7 +13,6 @@
 #include "postgres.h"
 
 #include "miscadmin.h"
-#include "libpq-fe.h"
 #include "pgstat.h"
 
 #include "access/htup_details.h"

--- a/pglogical_apply_heap.c
+++ b/pglogical_apply_heap.c
@@ -13,7 +13,6 @@
 #include "postgres.h"
 
 #include "miscadmin.h"
-#include "libpq-fe.h"
 #include "pgstat.h"
 
 #include "access/htup_details.h"

--- a/pglogical_conflict.c
+++ b/pglogical_conflict.c
@@ -12,8 +12,6 @@
  */
 #include "postgres.h"
 
-#include "libpq-fe.h"
-
 #include "miscadmin.h"
 
 #include "access/commit_ts.h"

--- a/pglogical_rpc.h
+++ b/pglogical_rpc.h
@@ -13,7 +13,7 @@
 #ifndef PGLOGICAL_RPC_H
 #define PGLOGICAL_RPC_H
 
-#include "libpq-fe.h"
+typedef struct pg_conn PGconn;
 
 extern List *pg_logical_get_remote_repset_tables(PGconn *conn,
 									List *replication_sets);

--- a/pglogical_sync.c
+++ b/pglogical_sync.c
@@ -21,8 +21,6 @@
 #include <sys/wait.h>
 #endif
 
-#include "libpq-fe.h"
-
 #include "miscadmin.h"
 
 #include "access/genam.h"

--- a/pglogical_sync.h
+++ b/pglogical_sync.h
@@ -13,8 +13,6 @@
 #ifndef PGLOGICAL_SYNC_H
 #define PGLOGICAL_SYNC_H
 
-#include "libpq-fe.h"
-
 #include "nodes/primnodes.h"
 #include "pglogical_node.h"
 


### PR DESCRIPTION
This serves a few distinct purposes:

- Beta-test the wrappers for PostgreSQL's benefit.

- Since libpq-be-fe-helpers.h activates the libpqsrv_PGresult wrappers unconditionally and #454 uses libpq-be-fe-helpers.h, #454 would activate the wrappers in some files.  By activating the wrappers first, this change isolates any wrapper-related side effects from other effects of #454.

- When postgr.es/c/7d8f5957792421ec3bb9d1b9b6ca25d689d974b7 introduced the wrappers to PostgreSQL 19, the motive was stopping memory leaks. The same benefit tends to apply here, though there have been no reports of PGresult leaks in pglogical.