### PR TITLE
Escape relation name

### DIFF
--- a/pglogical_proto_json.c
+++ b/pglogical_proto_json.c
@@ -118,10 +118,11 @@ pglogical_json_write_change(StringInfo out, const char *change, Relation rel,
 							Bitmapset *att_list)
 {
 	appendStringInfoChar(out, '{');
-	appendStringInfo(out, "\"action\":\"%s\",\"relation\":[\"%s\",\"%s\"]",
-					 change,
-					 get_namespace_name(RelationGetNamespace(rel)),
-					 RelationGetRelationName(rel));
+	appendStringInfo(out, "\"action\":\"%s\",\"relation\":[", change);
+	escape_json(out, get_namespace_name(RelationGetNamespace(rel)));
+	appendStringInfoChar(out, ',');
+	escape_json(out, RelationGetRelationName(rel));
+	appendStringInfoChar(out, ']');
 
 	if (oldtuple)
 	{


### PR DESCRIPTION
Use the standard escape_json() function to escape relation names in the JSON protocol.