### PR TITLE
Fix a copy-and-paste typo

### DIFF
--- a/pglogical_output_config.c
+++ b/pglogical_output_config.c
@@ -181,8 +181,8 @@ process_parameters_v1(List *options, PGLogicalOutputData *data)
 
 			case PARAM_BINARY_FLOAT8BYVAL:
 				val = get_param_value(elem, false, OUTPUT_PARAM_TYPE_BOOL);
-				data->client_binary_float4byval_set = true;
-				data->client_binary_float4byval = DatumGetBool(val);
+				data->client_binary_float8byval_set = true;
+				data->client_binary_float8byval = DatumGetBool(val);
 				break;
 
 			case PARAM_BINARY_INTEGER_DATETIMES:


### PR DESCRIPTION
In process_parameters_v1() the PARAM_BINARY_FLOAT8BYVAL set float4 fields instead of float8 fields. The result is that float8 by-value compatibility check is never executed.